### PR TITLE
Fix CR names for EE and OSS CRs

### DIFF
--- a/docs/modules/ROOT/examples/hazelcast.yaml
+++ b/docs/modules/ROOT/examples/hazelcast.yaml
@@ -1,4 +1,4 @@
 apiVersion: hazelcast.com/v1alpha1
 kind: Hazelcast
 metadata:
-  name: hazelcast
+  name: hazelcast-sample

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -161,15 +161,15 @@ kubectl get hazelcast
 ----
 
 ```
-NAME        STATUS    MEMBERS
-hazelcast   Running   3/3
+NAME               STATUS    MEMBERS
+hazelcast-sample   Running   3/3
 ```
 
 You can use the following command for the long format.
 
 [source,shell]
 ----
-kubectl get hazelcast -o=yaml
+kubectl get hazelcast hazelcast-sample -o=yaml
 ----
 
 [source,yaml,subs="attributes+"]


### PR DESCRIPTION
For consistency, I fixed the CR names for both OS and EE to `hazelcast-sample`

Fixes #10 