### PR TITLE
Fixed examples in scheduling-configuration page

### DIFF
--- a/docs/modules/ROOT/examples/hazelcast-pod-affinity.yaml
+++ b/docs/modules/ROOT/examples/hazelcast-pod-affinity.yaml
@@ -14,14 +14,14 @@ spec:
                   values:
                     - app1
             topologyKey: kubernetes.io/hostname
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 10
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app.kubernetes.io/instance
-                      operator: In
-                      values:
-                        - hazelcast
-                topologyKey: kubernetes.io/hostname
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                      - hazelcast
+              topologyKey: kubernetes.io/hostname

--- a/docs/modules/ROOT/examples/hazelcast-topology-spread-constraints.yaml
+++ b/docs/modules/ROOT/examples/hazelcast-topology-spread-constraints.yaml
@@ -7,8 +7,9 @@ spec:
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: corev1.DoNotSchedule
-        labelSelector: 
-          app.kubernetes.io/name: hazelcast
-          app.kubernetes.io/instance: hazelcast
-          app.kubernetes.io/managed-by: hazelcast-platform-operator
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: hazelcast
+            app.kubernetes.io/instance: hazelcast
+            app.kubernetes.io/managed-by: hazelcast-platform-operator

--- a/docs/modules/ROOT/pages/api-ref.adoc
+++ b/docs/modules/ROOT/pages/api-ref.adoc
@@ -66,7 +66,7 @@ TIP: This document was generated from comments in the Go code in the api/ direct
 |===
 | Field | Description | Type | Required | Default
 m| repository | Repository to pull Hazelcast Platform Operator Agent(https://github.com/hazelcast/platform-operator-agent) m| string | false | "docker.io/hazelcast/platform-operator-agent"
-m| version | Version of Hazelcast Platform Operator Agent. m| string | false | "0.1.2"
+m| version | Version of Hazelcast Platform Operator Agent. m| string | false | "0.1.3"
 |===
 
 <<Table of Contents,Back to TOC>>
@@ -211,7 +211,7 @@ m| clusterName | Name of the Hazelcast cluster. m| string | false | "dev"
 m| scheduling | Scheduling details m| &#42;<<SchedulingConfiguration,SchedulingConfiguration>> | false | {}
 m| resources | Compute Resources required by the Hazelcast container. m| &#42;https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#resourcerequirements-v1-core[corev1.ResourceRequirements] | false | {}
 m| persistence | Persistence configuration m| &#42;<<HazelcastPersistenceConfiguration,HazelcastPersistenceConfiguration>> | false | {}
-m| agent | B&R Agent configurations m| &#42;<<AgentConfiguration,AgentConfiguration>> | false | {repository: "docker.io/hazelcast/platform-operator-agent", version: "0.1.2"}
+m| agent | B&R Agent configurations m| &#42;<<AgentConfiguration,AgentConfiguration>> | false | {repository: "docker.io/hazelcast/platform-operator-agent", version: "0.1.3"}
 m| customClass | Custom Classes to Download into Class Path m| &#42;<<CustomClassConfiguration,CustomClassConfiguration>> | false | -
 |===
 


### PR DESCRIPTION
- fixed wrong indent in pod-antiffity

- fixed topology spread to as docs:
https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
```
whenUnsatisfiable indicates how to deal with a Pod if it doesn't satisfy the spread constraint:
- DoNotSchedule (default) tells the scheduler not to schedule it.
- ScheduleAnyway tells the scheduler to still schedule it while prioritizing nodes that minimize the skew.
``` 

```
$ k explain hazelcast.spec.scheduling.topologySpreadConstraints.labelSelector
KIND:     Hazelcast
VERSION:  hazelcast.com/v1alpha1

RESOURCE: labelSelector <Object>

DESCRIPTION:
     LabelSelector is used to find matching pods. Pods that match this label
     selector are counted to determine the number of pods in their corresponding
     topology domain.

FIELDS:
   matchExpressions	<[]Object>
     matchExpressions is a list of label selector requirements. The requirements
     are ANDed.

   matchLabels	<map[string]string>
     matchLabels is a map of {key,value} pairs. A single {key,value} in the
     matchLabels map is equivalent to an element of matchExpressions, whose key
     field is "key", the operator is "In", and the values array contains only
     "value". The requirements are ANDed.
```