### PR TITLE
fix TLS example

### DIFF
--- a/docs/modules/ROOT/examples/hazelcast-tls.yaml
+++ b/docs/modules/ROOT/examples/hazelcast-tls.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hazelcast
 spec:
   clusterSize: 3
+  repository: 'docker.io/hazelcast/hazelcast-enterprise'
   licenseKeySecret: hazelcast-license-key
   tls:
     secretName: example


### PR DESCRIPTION
TLS requires enterprise repository

`Error from server (TLS requires Hazelcast Enterprise version): error when creating "hazelcast.yaml": admission webhook "vhazelcast.kb.io" denied the request: TLS requires Hazelcast Enterprise version`