### PR TITLE
DOCS-524 Remove reference to Strim Tutorial

### DIFF
--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -80,9 +80,6 @@ content:
   - url: https://github.com/hazelcast-guides/ecs-embedded
     branches: master
     start_path: docs
-  - url: https://github.com/hazelcast-guides/striim-cdc
-    branches: master
-    start_path: docs
   - url: https://github.com/hazelcast-guides/springboot-tomcat-session-replication
     branches: master
     start_path: docs


### PR DESCRIPTION
Remove reference to Striim Tutorial. We no longer partner with them.