### PR TITLE
Update Hazelcast documentation link version

### DIFF
--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -224,7 +224,7 @@ NOTE: For restore to be successful you have to give restore configuration at the
 
 === Data Recovery Timeout
 
-To choose a data recovery timeout, you can use dataRecoveryTimeout. The field takes an integer value representing the timeout in seconds and uses this value to set link:https://docs.hazelcast.com/hazelcast/5.1/storage/configuring-persistence#global-persistence-options[validation-timeout-seconds, data-load-timeout-seconds] Hazelcast Persistence options.
+To choose a data recovery timeout, you can use dataRecoveryTimeout. The field takes an integer value representing the timeout in seconds and uses this value to set link:https://docs.hazelcast.com/hazelcast/latest/storage/configuring-persistence#global-persistence-options[validation-timeout-seconds, data-load-timeout-seconds] Hazelcast Persistence options.
 
 [source,yaml,subs="attributes+"]
 ----

--- a/docs/modules/ROOT/pages/jvm-parameters.adoc
+++ b/docs/modules/ROOT/pages/jvm-parameters.adoc
@@ -54,7 +54,7 @@ include::ROOT:example$/jvm_gc_logging.yaml[]
 It is going to set the following JVM argument: `-verbose:gc`
 
 === Setting the Garbage Collector
-WARNING: Before making Garbage Collector related changes using the Hazelcast Platform Operator, it is highly recommended to read link:https://docs.hazelcast.com/hazelcast/5.2/capacity-planning#garbage-collection-considerations[Garbage Collector Considerations section of Capacity Planning Document] to decide which Garbage Collector to use.
+WARNING: Before making Garbage Collector related changes using the Hazelcast Platform Operator, it is highly recommended to read link:https://docs.hazelcast.com/hazelcast/latest/capacity-planning#garbage-collection-considerations[Garbage Collector Considerations section of Capacity Planning Document] to decide which Garbage Collector to use.
 
 To set the Garbage Collector, following configuration can be used:
 


### PR DESCRIPTION
Replace any references to `https://docs.hazelcast.com/hazelcast/5.x` with `https://docs.hazelcast.com/hazelcast/latest`