### PR TITLE
DOCS-700_Correct_Smart_Client_Example

### DIFF
--- a/docs/modules/ROOT/pages/connect-outside-kubernetes.adoc
+++ b/docs/modules/ROOT/pages/connect-outside-kubernetes.adoc
@@ -136,7 +136,6 @@ Java::
 ----
 ClientConfig config = new ClientConfig();
 config.getNetworkConfig().addAddress("35.230.92.217");
-config.getNetworkConfig().setSmartRouting(false);
 HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
 ----
 --


### PR DESCRIPTION
Removed line in Java example that turned the Smart Client off