### PR TITLE
Remove unnecessary notes on restoring

### DIFF
--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -171,9 +171,6 @@ include::ROOT:example$/hazelcast-persistence-restore-cr-name.yaml[]
     The agent configuration is optional. If you give `restore` under `persistence` and do not pass the agent configuration, Hazelcast Platform Operator
     uses the latest agent version that is compatible with its version.
 
-NOTE: For restore to be successful you have to give restore configuration at the `Hazelcast` custom resource creation. Otherwise, triggering restore on currently running members will likely to fail. 
-
-
 == Restoring from External Backups
 
 To restore a cluster from external backups, you can either set up the bucket configuration or give the `HotBackup` resource name that you used to trigger the external backup. In either case, the backup is restored from the external bucket.
@@ -214,8 +211,6 @@ include::ROOT:example$/hazelcast-persistence-restore-cr-name.yaml[]
 --
 
 ====
-
-NOTE: For restore to be successful you have to give restore configuration at the `Hazelcast` custom resource creation. Otherwise, triggering restore on currently running members will likely to fail. 
 
 == Configuring Persistence
 


### PR DESCRIPTION
We already have a webhook validation that disallows users from updating the restore section in `Hazelcast` resources.

> The Hazelcast "my-hazelcast" is invalid: spec.persistence.restore: Forbidden: field cannot be updated

