### PR TITLE
Tip for local backup CR name

### DIFF
--- a/docs/modules/ROOT/examples/hazelcast-persistence-restore-cr-name.yaml
+++ b/docs/modules/ROOT/examples/hazelcast-persistence-restore-cr-name.yaml
@@ -1,7 +1,7 @@
 apiVersion: hazelcast.com/v1alpha1
 kind: Hazelcast
 metadata:
-  name: hazelcast
+  name: hazelcast <1>
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
@@ -12,6 +12,6 @@ spec:
       accessModes: ["ReadWriteOnce"]
       requestStorage: 20Gi
     restore:
-      hotBackupResourceName: hot-backup <1>
-  agent: <2>
+      hotBackupResourceName: hot-backup <2>
+  agent: <3>
     repository: hazelcast/platform-operator-agent

--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -172,7 +172,7 @@ include::ROOT:example$/hazelcast-persistence-restore-cr-name.yaml[]
 ----
 
 <1> Hazelcast custom resource name for both backup and restore CRs must be the same, otherwise, the restore fails.
-<2> `HotBackup` resource name used for restore. The backup folder name will be taken from the `HotBackup` resource.
+<2> `HotBackup` resource name used for the restore. The backup folder name will be the name you provide here.
 <3> Agent responsible for restoring data from the local storage.
 The agent configuration is optional. If you give `restore` under `persistence` and do not pass the agent configuration, Hazelcast Platform Operator
 uses the latest agent version that is compatible with its version.

--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -177,7 +177,7 @@ include::ROOT:example$/hazelcast-persistence-restore-cr-name.yaml[]
 The agent configuration is optional. If you give `restore` under `persistence` and do not pass the agent configuration, Hazelcast Platform Operator
 uses the latest agent version that is compatible with its version.
 
-WARNING:: You can only use a local backup once to restore a cluster. It is recommended to backup externally if you need to persistently restore a backup across clusters.
+WARNING: You can only use a local backup once to restore a cluster. It is recommended to backup externally if you need to persistently restore a backup across clusters.
 
 === Restoring from Local Backups Created with other Methods
 

--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -177,7 +177,7 @@ include::ROOT:example$/hazelcast-persistence-restore-cr-name.yaml[]
 The agent configuration is optional. If you give `restore` under `persistence` and do not pass the agent configuration, Hazelcast Platform Operator
 uses the latest agent version that is compatible with its version.
 
-WARNING: You can only use a local backup once to restore a cluster. It is recommended to backup externally if you need to persistently restore a backup across clusters.
+WARNING: You can use a local backup only once to restore a cluster. We recommend you backup externally if you need to persistently restore a backup across the clusters.
 
 === Restoring from Local Backups Created with other Methods
 

--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -171,10 +171,13 @@ deployed with the Hazelcast container in the same Pod. The agent starts as an in
 include::ROOT:example$/hazelcast-persistence-restore-cr-name.yaml[]
 ----
 
-<1> `HotBackup` resource name used for restore. The backup folder name will be taken from the `HotBackup` resource.
-<2> Agent responsible for restoring data from the local storage.
+<1> The name of the Hazelcast custom resource for both backup and restore must be the same. If the Hazelcast custom resource name is different, the restore fails.
+<2> `HotBackup` resource name used for restore. The backup folder name will be taken from the `HotBackup` resource.
+<3> Agent responsible for restoring data from the local storage.
 The agent configuration is optional. If you give `restore` under `persistence` and do not pass the agent configuration, Hazelcast Platform Operator
 uses the latest agent version that is compatible with its version.
+
+WARNING:: You can only use a local backup once to restore a cluster. It is recommended to backup externally if you need to persistently restore a backup across clusters.
 
 === Restoring from Local Backups Created with other Methods
 
@@ -203,8 +206,6 @@ include::ROOT:example$/pod-local-pvc-content.yaml[]
 <3> Replace with the name of the one of the PVCs, which is mounted to the cluster from which the backup is taken.
 
 NOTE: Agent copies the backup to be restored from `{baseDir}/{backupDir}/{backupFolder}` to `/data/persistence/base-dir`.
-
-Note: You can only use a local backup once to restore a cluster. It is recommended to backup externally if you need to persistently restore a backup across clusters.
 
 == Restoring from External Backups
 

--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -171,7 +171,7 @@ deployed with the Hazelcast container in the same Pod. The agent starts as an in
 include::ROOT:example$/hazelcast-persistence-restore-cr-name.yaml[]
 ----
 
-<1> The name of the Hazelcast custom resource for both backup and restore must be the same. If the Hazelcast custom resource name is different, the restore fails.
+<1> Hazelcast custom resource name for both backup and restore CRs must be the same, otherwise, the restore fails.
 <2> `HotBackup` resource name used for restore. The backup folder name will be taken from the `HotBackup` resource.
 <3> Agent responsible for restoring data from the local storage.
 The agent configuration is optional. If you give `restore` under `persistence` and do not pass the agent configuration, Hazelcast Platform Operator

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -51,7 +51,7 @@ Run the following commands to *deploy the Operator and the CRDs separately*. An 
 helm install operator-crds hazelcast/hazelcast-platform-operator-crds --version={operator-chart-version}
 ----
 
-After installing CRDs, install the Operator by running the following command. This operation requires only namespace-scoped permissions for `hz-system`, `ns-1` and `ns-2` namespaces and they already exist.
+After installing CRDs, install the Operator by running the following command. This operation requires only namespace-scoped permissions for `hz-system`, `ns-1` and `ns-2` namespaces which should already exist.
 
 [source,shell,subs="attributes"]
 ----


### PR DESCRIPTION
Changes:
- added tip for local backup CR name for restore operation
- move the local backup note to related section and convert it into a warning
- clarify namespace requirement at getting started page