### PR TITLE
Remove IMDG documentation references

### DIFF
--- a/docs/modules/ROOT/pages/hazelcast-parameters.adoc
+++ b/docs/modules/ROOT/pages/hazelcast-parameters.adoc
@@ -1,10 +1,10 @@
 = Configuring System Properties
 
-You can configure Hazelcast parameters using the `properties` field in the CRD spec. You can find all properties in link:https://docs.hazelcast.com/hazelcast/5.3/system-properties[System Properties] document.
+You can configure Hazelcast parameters using the `properties` field in the CRD spec. You can find all properties in link:https://docs.hazelcast.com/hazelcast/latest/system-properties[System Properties] document.
 
 It is worth highlighting the following system properties:
 
-- During a rolling upgrade, the cluster is shutdown gracefully to prevent data loss. You can configure this using the link:https://docs.hazelcast.com/hazelcast/5.3/system-properties#hazelcast.graceful.shutdown.max.wait[hazelcast.graceful.shutdown.max.wait system property].
+- During a rolling upgrade, the cluster is shutdown gracefully to prevent data loss. You can configure this using the link:https://docs.hazelcast.com/hazelcast/latest/system-properties#hazelcast.graceful.shutdown.max.wait[hazelcast.graceful.shutdown.max.wait system property].
 +
 Example Configuration:
 +
@@ -15,6 +15,6 @@ include::ROOT:example$/properties.yaml[]
 
 Hazelcast Platform Operator sets the following system properties to the default values, which cannot be changed:
 
-- The final step in the link:https://docs.hazelcast.com/hazelcast/5.3/maintain-cluster/rolling-upgrades#rolling-upgrade-procedure[rolling upgrade procedure] is to trigger a rolling upgrade on the cluster. Hazelcast Platform Operator triggers it automatically by setting `hazelcast.cluster.version.auto.upgrade.enabled` to `true` by default.
+- The final step in the link:https://docs.hazelcast.com/hazelcast/latest/maintain-cluster/rolling-upgrades#rolling-upgrade-procedure[rolling upgrade procedure] is to trigger a rolling upgrade on the cluster. Hazelcast Platform Operator triggers it automatically by setting `hazelcast.cluster.version.auto.upgrade.enabled` to `true` by default.
 
 - `hazelcast.persistence.auto.cluster.state` set to `true` by default.

--- a/docs/modules/ROOT/pages/map-configuration.adoc
+++ b/docs/modules/ROOT/pages/map-configuration.adoc
@@ -55,14 +55,14 @@ NOTE: Persistence should be enabled for Hazelcast before enabling it for the map
 - propertiesSecretName: Name of the secret holding the properties for the MapStore classes implementing the `MapLoaderLifecycleSupport` interface.
 
 |entryListeners
-|Configuration options for listening for the map-level or entry-based events using the listeners provided by the Hazelcast’s eventing framework. You can learn more at link:https://docs.hazelcast.com/imdg/latest/events/object-events[Distributed Object Events].
+|Configuration options for listening for the map-level or entry-based events using the listeners provided by the Hazelcast’s eventing framework. You can learn more at link:https://docs.hazelcast.com/hazelcast/latest/events/object-events[Distributed Object Events].
 
 - className: Name of your class implementing a `MapListener` sub-interface.
 - includeValues: An optional attribute that indicates whether the map event should contains the map value.
 - local: An optional attribute that indicates whether you can listen to the map on the local member.
 
 |nearCache
-|Configuration options for server side `Near Cache`. You can learn more at link:https://docs.hazelcast.com/imdg/4.2/performance/near-cache[Near Cache].
+|Configuration options for server side `Near Cache`. You can learn more at link:https://docs.hazelcast.com/hazelcast/latest/cluster-performance/best-practices#near-cache[Near Cache].
 
 - name: name of the near cache.
 - inMemoryFormat: specifies in which format data will be stored in your near cache.


### PR DESCRIPTION
Replace IMDG documentation links to latest Hazelcast documentation.

Also updated existing Hazelcast `5.x` links to use `latest` instead