### PR TITLE
Fix WN link by updating latest supported versions

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -11,7 +11,7 @@ asciidoc:
     operator-chart-version: '5.13.0'
     page-toclevels: 1@
     # page-latest-supported versions are used for sample YAML files.
-    page-latest-supported-mc: '5.5.0'
-    page-latest-supported-hazelcast: '5.5.0'
+    page-latest-supported-mc: '5.5'
+    page-latest-supported-hazelcast: '5.5'
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
From comparison with MC, we need x.y only.

Currently, link in What's New page (https://docs.hazelcast.com/operator/5.13/whats-new) is broken - points to https://docs.hazelcast.com/operator/5.13/whats-new#5.5.0@hazelcast:ROOT:whats-new.adoc