### PR TITLE
Removed references to hazelcast.yaml - standardise on hazelcast-enterprise.yaml

### DIFF
--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -99,7 +99,7 @@ oc logs deployment.apps/operator-hazelcast-platform-operator -n hz-system
 
 == Step 2. Start the Hazelcast Cluster
 
-After installing and running the Hazelcast Platform Operator, you can create a Hazelcast cluster. First, create the `Hazelcast` custom resource file as `hazelcast.yaml`.
+After installing and running the Hazelcast Platform Operator, you can create a Hazelcast cluster. 
 
 Hazelcast Enterprise requires a license key. If you don't have a license key, you can request one from the link:http://trialrequest.hazelcast.com/[Hazelcast website].
 
@@ -238,28 +238,6 @@ WARNING: Use the `readyMembers` field only for informational purposes. This fiel
 
 
 == Step 4. Clean up
-
-You can run the commands below to remove the Hazelcast cluster.
-
-[tabs]
-====
-Kubernetes::
-+
---
-[source,shell]
-----
-kubectl delete -f hazelcast.yaml
-----
---
-Openshift::
-+
---
-[source,shell]
-----
-oc delete -f hazelcast.yaml
-----
---
-====
 
 Run the following commands to remove Hazelcast cluster and Hazelcast License Key Secret.
 


### PR DESCRIPTION
Now that operator is enterprise only, we should only reference `hazelcast-enterprise.yaml` as the file containing the Hazelcast Custom Resource Definitions.   Steps 2.2 & 2.3 already reference `hazelcast-enterprise.yaml` for creating the Hazelcast cluster.    

As shown in https://github.com/hazelcast/hazelcast-platform-operator-docs/issues/175 previously Step 2 contained two tabs (Open Source) and (Enterprise) with the Open Source steps using `hazelcast.yaml` and Enterprise using `hazelcast-enterprise.yaml`.   The Open Source tab has been removed so we can remove all references to `hazelcast.yaml` 

