### PR TITLE
Fix build errors v/5.10

### DIFF
--- a/docs/modules/ROOT/examples/management-center-ldap.yaml
+++ b/docs/modules/ROOT/examples/management-center-ldap.yaml
@@ -9,7 +9,7 @@ spec:
     ldap:
       credentialsSecretName: ldap-credentianls
       groupDN: ou=users,dc=example,dc=org
-      groupSearchFilter: member={0}
+      groupSearchFilter: member=\{0}
       nestedGroupSearch: false
       url: ldap://ldap-server-url:1389
       userDN: ou=users,dc=example,dc=org
@@ -21,4 +21,4 @@ spec:
       - admins
       readonlyUserGroups:
       - readers
-      userSearchFilter: cn={0}
+      userSearchFilter: cn=\{0}

--- a/docs/modules/ROOT/pages/api-ref.adoc
+++ b/docs/modules/ROOT/pages/api-ref.adoc
@@ -6,7 +6,7 @@ A reference guide to the Hazelcast Platform Operator CRD types.
 == Hazelcast Platform Operator API Docs
 
 This is a reference for the Hazelcast Platform Operator API types.
-These are all the types and fields that are used in the Hazelcast Platform Operator CRDs. 
+These are all the types and fields that are used in the Hazelcast Platform Operator CRDs.
 
 TIP: This document was generated from comments in the Go code in the api/ directory.
 
@@ -1077,8 +1077,8 @@ m| adminGroups | Members of these groups and its nested groups have admin privil
 m| userGroups | Members of these groups and its nested groups have read and write privileges on the Management Center. m| []string | true | -
 m| readonlyUserGroups | Members of these groups and its nested groups have only read privilege on the Management Center. m| []string | true | -
 m| metricsOnlyGroups | Members of these groups and its nested groups have the privilege to see only the metrics on the Management Center. m| []string | true | -
-m| userSearchFilter | LDAP search filter expression to search for the users. For example, uid={0} searches for a username that matches with the uid attribute. m| string | true | -
-m| groupSearchFilter | LDAP search filter expression to search for the groups. For example, uniquemember={0} searches for a group that matches with the uniquemember attribute. m| string | true | -
+m| userSearchFilter | LDAP search filter expression to search for the users. For example, uid=\{0} searches for a username that matches with the uid attribute. m| string | true | -
+m| groupSearchFilter | LDAP search filter expression to search for the groups. For example, uniquemember=\{0} searches for a group that matches with the uniquemember attribute. m| string | true | -
 m| nestedGroupSearch | NestedGroupSearch enables searching for nested LDAP groups. m| bool | true | false
 |===
 

--- a/docs/modules/ROOT/pages/jet-job-configuration.adoc
+++ b/docs/modules/ROOT/pages/jet-job-configuration.adoc
@@ -62,3 +62,4 @@ The following `JetJob` resource runs the Data Pipeline for the `Hazelcast` resou
 [source,yaml,subs="attributes+"]
 ----
 include::ROOT:example$/jet-job-example.yaml[]
+----


### PR DESCRIPTION
Fixes
```
2:31:13 PM: [11:31:13.370] WARN (asciidoctor): skipping reference to missing attribute: 0
2:31:13 PM:     file: docs/modules/ROOT/pages/api-ref.adoc
2:31:13 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.10 | start path: docs)
2:31:13 PM: [11:31:13.371] WARN (asciidoctor): skipping reference to missing attribute: 0
2:31:13 PM:     file: docs/modules/ROOT/pages/api-ref.adoc
2:31:13 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.10 | start path: docs)
2:31:13 PM: [11:31:13.716] WARN (asciidoctor): unterminated listing block
2:31:13 PM:     file: docs/modules/ROOT/examples/jet-job-example.yaml
2:31:13 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.10 | start path: docs)
2:31:13 PM:     stack:
2:31:13 PM:         file: docs/modules/ROOT/pages/jet-job-configuration.adoc:64
2:31:13 PM: [11:31:13.831] WARN (asciidoctor): skipping reference to missing attribute: 0
2:31:13 PM:     file: docs/modules/ROOT/pages/management-center-ldap.adoc
2:31:13 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.10 | start path: docs)
2:31:13 PM: [11:31:13.832] WARN (asciidoctor): skipping reference to missing attribute: 0
2:31:13 PM:     file: docs/modules/ROOT/pages/management-center-ldap.adoc
2:31:13 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.10 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e17df24ad58000080e1b33#L308
