### PR TITLE
Fix errors v/5.11

### DIFF
--- a/docs/modules/ROOT/examples/management-center-ldap.yaml
+++ b/docs/modules/ROOT/examples/management-center-ldap.yaml
@@ -9,7 +9,7 @@ spec:
     ldap:
       credentialsSecretName: ldap-credentianls
       groupDN: ou=users,dc=example,dc=org
-      groupSearchFilter: member={0}
+      groupSearchFilter: member=\{0}
       nestedGroupSearch: false
       url: ldap://ldap-server-url:1389
       userDN: ou=users,dc=example,dc=org
@@ -21,4 +21,4 @@ spec:
       - admins
       readonlyUserGroups:
       - readers
-      userSearchFilter: cn={0}
+      userSearchFilter: cn=\{0}

--- a/docs/modules/ROOT/pages/api-ref.adoc
+++ b/docs/modules/ROOT/pages/api-ref.adoc
@@ -6,7 +6,7 @@ A reference guide to the Hazelcast Platform Operator CRD types.
 == Hazelcast Platform Operator API Docs
 
 This is a reference for the Hazelcast Platform Operator API types.
-These are all the types and fields that are used in the Hazelcast Platform Operator CRDs. 
+These are all the types and fields that are used in the Hazelcast Platform Operator CRDs.
 
 TIP: This document was generated from comments in the Go code in the api/ directory.
 
@@ -1135,8 +1135,8 @@ m| adminGroups | Members of these groups and its nested groups have admin privil
 m| userGroups | Members of these groups and its nested groups have read and write privileges on the Management Center. m| []string | true | -
 m| readonlyUserGroups | Members of these groups and its nested groups have only read privilege on the Management Center. m| []string | true | -
 m| metricsOnlyGroups | Members of these groups and its nested groups have the privilege to see only the metrics on the Management Center. m| []string | true | -
-m| userSearchFilter | LDAP search filter expression to search for the users. For example, uid={0} searches for a username that matches with the uid attribute. m| string | true | -
-m| groupSearchFilter | LDAP search filter expression to search for the groups. For example, uniquemember={0} searches for a group that matches with the uniquemember attribute. m| string | true | -
+m| userSearchFilter | LDAP search filter expression to search for the users. For example, uid=\{0} searches for a username that matches with the uid attribute. m| string | true | -
+m| groupSearchFilter | LDAP search filter expression to search for the groups. For example, uniquemember=\{0} searches for a group that matches with the uniquemember attribute. m| string | true | -
 m| nestedGroupSearch | NestedGroupSearch enables searching for nested LDAP groups. m| bool | true | false
 |===
 

--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -247,7 +247,7 @@ include::ROOT:example$/pod-local-pvc-content.yaml[]
 <2> Replace `/data/persistence` with the correct mountPath specified in PV.
 <3> Replace with the name of the one of the PVCs, which is mounted to the cluster from which the backup is taken.
 
-NOTE: Agent copies the backup to be restored from `{baseDir}/{backupDir}/{backupFolder}` to `/data/persistence/base-dir`.
+NOTE: Agent copies the backup to be restored from `\{baseDir}/\{backupDir}/\{backupFolder}` to `/data/persistence/base-dir`.
 
 == Configuring Persistence
 

--- a/docs/modules/ROOT/pages/jet-job-configuration.adoc
+++ b/docs/modules/ROOT/pages/jet-job-configuration.adoc
@@ -62,3 +62,4 @@ The following `JetJob` resource runs the Data Pipeline for the `Hazelcast` resou
 [source,yaml,subs="attributes+"]
 ----
 include::ROOT:example$/jet-job-example.yaml[]
+----

--- a/docs/modules/ROOT/pages/user-code-deployment.adoc
+++ b/docs/modules/ROOT/pages/user-code-deployment.adoc
@@ -40,7 +40,7 @@ WARNING: The data stored in a ConfigMap cannot exceed 1 MiB. For more info, see 
 The example configuration below:
 
 * downloads the JAR files from the specified external bucket and places them under the classpath of each of the Hazelcast members
-* puts all the files specified in the ConfigMap objects under the classpath of each of the Hazelcast members. 
+* puts all the files specified in the ConfigMap objects under the classpath of each of the Hazelcast members.
 
 WARNING: Currently, mounted persistent volumes are not supported; only cloud provider external buckets are supported.
 
@@ -116,7 +116,7 @@ Use the following configuration options in the `Map` resource for a MapStore. Th
 
 === Example MapStore Configuration
 
-An example `Map` resource with MapStore configuration. 
+An example `Map` resource with MapStore configuration.
 
 .Example configuration
 [source,yaml,subs="attributes+"]
@@ -139,7 +139,7 @@ There are three variants of the executor service:
 - Durable Executor Service
 - Scheduled Executor Service.
 
-Configuration options for a `Hazelcast` resource to work with all three variants are shown in this section, along with examples of how you might implement these options. For more detailed implementation information, see xref:hazelcast:computing:executor-service.adoc[Java Executor Service]. 
+Configuration options for a `Hazelcast` resource to work with all three variants are shown in this section, along with examples of how you might implement these options. For more detailed implementation information, see xref:hazelcast:computing:executor-service.adoc[Java Executor Service].
 
 
 [tabs]
@@ -255,4 +255,4 @@ include::ROOT:example$/hazelcast-scheduled-executor-service.yaml[]
 
 == Configuring an Entry Processor with Hazelcast Platform Operator
 
-An entry processor executes your code on a map entry in an atomic way. To implement the `EntryProcessor` interface, you can deploy an `EntryProcessor` class from the Hazelcast Platform Operator to the classpath of a Hazelcast member. See xref:hazelcast:computing:entry-processor.adoc[Entry Processor] for more detailed information.
+An entry processor executes your code on a map entry in an atomic way. To implement the `EntryProcessor` interface, you can deploy an `EntryProcessor` class from the Hazelcast Platform Operator to the classpath of a Hazelcast member. See xref:hazelcast:data-structures:entry-processor.adoc[Entry Processor] for more detailed information.


### PR DESCRIPTION
Fixes
```
2:31:14 PM: [11:31:14.429] WARN (asciidoctor): skipping reference to missing attribute: 0
2:31:14 PM:     file: docs/modules/ROOT/pages/api-ref.adoc
2:31:14 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.11 | start path: docs)
2:31:14 PM: [11:31:14.429] WARN (asciidoctor): skipping reference to missing attribute: 0
2:31:14 PM:     file: docs/modules/ROOT/pages/api-ref.adoc
2:31:14 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.11 | start path: docs)
2:31:14 PM: [11:31:14.529] WARN (asciidoctor): skipping reference to missing attribute: basedir
2:31:14 PM:     file: docs/modules/ROOT/pages/backup-restore.adoc
2:31:14 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.11 | start path: docs)
2:31:14 PM: [11:31:14.529] WARN (asciidoctor): skipping reference to missing attribute: backupdir
2:31:14 PM:     file: docs/modules/ROOT/pages/backup-restore.adoc
2:31:14 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.11 | start path: docs)
2:31:14 PM: [11:31:14.529] WARN (asciidoctor): skipping reference to missing attribute: backupfolder
2:31:14 PM:     file: docs/modules/ROOT/pages/backup-restore.adoc
2:31:14 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.11 | start path: docs)
2:31:14 PM: [11:31:14.761] WARN (asciidoctor): unterminated listing block
2:31:14 PM:     file: docs/modules/ROOT/examples/jet-job-example.yaml
2:31:14 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.11 | start path: docs)
2:31:14 PM:     stack:
2:31:14 PM:         file: docs/modules/ROOT/pages/jet-job-configuration.adoc:64
2:31:14 PM: [11:31:14.879] WARN (asciidoctor): skipping reference to missing attribute: 0
2:31:14 PM:     file: docs/modules/ROOT/pages/management-center-ldap.adoc
2:31:14 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.11 | start path: docs)
2:31:14 PM: [11:31:14.879] WARN (asciidoctor): skipping reference to missing attribute: 0
2:31:14 PM:     file: docs/modules/ROOT/pages/management-center-ldap.adoc
2:31:14 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.11 | start path: docs)
2:31:15 PM: [11:31:15.197] ERROR (asciidoctor): target of xref not found: hazelcast:computing:entry-processor.adoc
2:31:15 PM:     file: docs/modules/ROOT/pages/user-code-deployment.adoc
2:31:15 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.11 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e17df24ad58000080e1b33#L325