### PR TITLE
Fix build errors v/5.12

### DIFF
--- a/docs/modules/ROOT/examples/management-center-ldap.yaml
+++ b/docs/modules/ROOT/examples/management-center-ldap.yaml
@@ -9,7 +9,7 @@ spec:
     ldap:
       credentialsSecretName: ldap-credentianls
       groupDN: ou=users,dc=example,dc=org
-      groupSearchFilter: member={0}
+      groupSearchFilter: member=\{0}
       nestedGroupSearch: false
       url: ldap://ldap-server-url:1389
       userDN: ou=users,dc=example,dc=org
@@ -21,4 +21,4 @@ spec:
       - admins
       readonlyUserGroups:
       - readers
-      userSearchFilter: cn={0}
+      userSearchFilter: cn=\{0}

--- a/docs/modules/ROOT/pages/api-ref.adoc
+++ b/docs/modules/ROOT/pages/api-ref.adoc
@@ -6,7 +6,7 @@ A reference guide to the Hazelcast Platform Operator CRD types.
 == Hazelcast Platform Operator API Docs
 
 This is a reference for the Hazelcast Platform Operator API types.
-These are all the types and fields that are used in the Hazelcast Platform Operator CRDs. 
+These are all the types and fields that are used in the Hazelcast Platform Operator CRDs.
 
 TIP: This document was generated from comments in the Go code in the api/ directory.
 
@@ -1146,8 +1146,8 @@ m| adminGroups | Members of these groups and its nested groups have admin privil
 m| userGroups | Members of these groups and its nested groups have read and write privileges on the Management Center. m| []string | true | -
 m| readonlyUserGroups | Members of these groups and its nested groups have only read privilege on the Management Center. m| []string | true | -
 m| metricsOnlyGroups | Members of these groups and its nested groups have the privilege to see only the metrics on the Management Center. m| []string | true | -
-m| userSearchFilter | LDAP search filter expression to search for the users. For example, uid={0} searches for a username that matches with the uid attribute. m| string | true | -
-m| groupSearchFilter | LDAP search filter expression to search for the groups. For example, uniquemember={0} searches for a group that matches with the uniquemember attribute. m| string | true | -
+m| userSearchFilter | LDAP search filter expression to search for the users. For example, uid=\{0} searches for a username that matches with the uid attribute. m| string | true | -
+m| groupSearchFilter | LDAP search filter expression to search for the groups. For example, uniquemember=\{0} searches for a group that matches with the uniquemember attribute. m| string | true | -
 m| nestedGroupSearch | NestedGroupSearch enables searching for nested LDAP groups. m| bool | true | false
 |===
 

--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -247,7 +247,7 @@ include::ROOT:example$/pod-local-pvc-content.yaml[]
 <2> Replace `/data/persistence` with the correct mountPath specified in PV.
 <3> Replace with the name of the one of the PVCs, which is mounted to the cluster from which the backup is taken.
 
-NOTE: Agent copies the backup to be restored from `{baseDir}/{backupDir}/{backupFolder}` to `/data/persistence/base-dir`.
+NOTE: Agent copies the backup to be restored from `\{baseDir}/\{backupDir}/\{backupFolder}` to `/data/persistence/base-dir`.
 
 == Configuring Persistence
 

--- a/docs/modules/ROOT/pages/jet-job-configuration.adoc
+++ b/docs/modules/ROOT/pages/jet-job-configuration.adoc
@@ -62,3 +62,4 @@ The following `JetJob` resource runs the Data Pipeline for the `Hazelcast` resou
 [source,yaml,subs="attributes+"]
 ----
 include::ROOT:example$/jet-job-example.yaml[]
+----

--- a/docs/modules/ROOT/pages/user-code-deployment.adoc
+++ b/docs/modules/ROOT/pages/user-code-deployment.adoc
@@ -42,7 +42,7 @@ WARNING: The data stored in a ConfigMap cannot exceed 1 MiB. For more info, see 
 The example configuration below:
 
 * downloads the JAR files from the specified external bucket and places them under the classpath of each of the Hazelcast members
-* puts all the files specified in the ConfigMap objects under the classpath of each of the Hazelcast members. 
+* puts all the files specified in the ConfigMap objects under the classpath of each of the Hazelcast members.
 
 WARNING: Currently, mounted persistent volumes are not supported; only cloud provider external buckets are supported.
 
@@ -118,7 +118,7 @@ Use the following configuration options in the `Map` resource for a MapStore. Th
 
 === Example MapStore Configuration
 
-An example `Map` resource with MapStore configuration. 
+An example `Map` resource with MapStore configuration.
 
 .Example configuration
 [source,yaml,subs="attributes+"]
@@ -141,7 +141,7 @@ There are three variants of the executor service:
 - Durable Executor Service
 - Scheduled Executor Service.
 
-Configuration options for a `Hazelcast` resource to work with all three variants are shown in this section, along with examples of how you might implement these options. For more detailed implementation information, see xref:hazelcast:computing:executor-service.adoc[Java Executor Service]. 
+Configuration options for a `Hazelcast` resource to work with all three variants are shown in this section, along with examples of how you might implement these options. For more detailed implementation information, see xref:hazelcast:computing:executor-service.adoc[Java Executor Service].
 
 
 [tabs]
@@ -257,4 +257,4 @@ include::ROOT:example$/hazelcast-scheduled-executor-service.yaml[]
 
 == Configuring an Entry Processor with Hazelcast Platform Operator
 
-An entry processor executes your code on a map entry in an atomic way. To implement the `EntryProcessor` interface, you can deploy an `EntryProcessor` class from the Hazelcast Platform Operator to the classpath of a Hazelcast member. See xref:hazelcast:computing:entry-processor.adoc[Entry Processor] for more detailed information.
+An entry processor executes your code on a map entry in an atomic way. To implement the `EntryProcessor` interface, you can deploy an `EntryProcessor` class from the Hazelcast Platform Operator to the classpath of a Hazelcast member. See xref:hazelcast:data-structures:entry-processor.adoc[Entry Processor] for more detailed information.

--- a/docs/modules/ROOT/pages/user-code-namespaces.adoc
+++ b/docs/modules/ROOT/pages/user-code-namespaces.adoc
@@ -1,5 +1,5 @@
 = User Code Namespaces
-:description: User Code Namespaces provide a container for Java classpath resources, such as user code and accompanying artifacts like property files. This provides namespace isolation to ensure that access to resources in different namespaces can be managed through configuration. From Hazelcast Platform Operator, you can deploy your application code from external buckets using UserCodeNamespace CRs. 
+:description: User Code Namespaces provide a container for Java classpath resources, such as user code and accompanying artifacts like property files. This provides namespace isolation to ensure that access to resources in different namespaces can be managed through configuration. From Hazelcast Platform Operator, you can deploy your application code from external buckets using UserCodeNamespace CRs.
 
 {description}
 
@@ -61,4 +61,4 @@ To allow your data structures to resolve your user code, you must reference the 
 [source,yaml,subs="attributes+"]
 ----
 include::ROOT:example$/map-ucn.yaml[]
----
+----


### PR DESCRIPTION
Fixes
```
7:07:17 PM: [16:07:17.096] WARN (asciidoctor): skipping reference to missing attribute: 0
7:07:17 PM:     file: docs/modules/ROOT/pages/api-ref.adoc
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM: [16:07:17.097] WARN (asciidoctor): skipping reference to missing attribute: 0
7:07:17 PM:     file: docs/modules/ROOT/pages/api-ref.adoc
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM: [16:07:17.211] WARN (asciidoctor): skipping reference to missing attribute: basedir
7:07:17 PM:     file: docs/modules/ROOT/pages/backup-restore.adoc
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM: [16:07:17.212] WARN (asciidoctor): skipping reference to missing attribute: backupdir
7:07:17 PM:     file: docs/modules/ROOT/pages/backup-restore.adoc
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM: [16:07:17.212] WARN (asciidoctor): skipping reference to missing attribute: backupfolder
7:07:17 PM:     file: docs/modules/ROOT/pages/backup-restore.adoc
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM: [16:07:17.454] WARN (asciidoctor): unterminated listing block
7:07:17 PM:     file: docs/modules/ROOT/examples/jet-job-example.yaml
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM:     stack:
7:07:17 PM:         file: docs/modules/ROOT/pages/jet-job-configuration.adoc:64
7:07:17 PM: [16:07:17.571] WARN (asciidoctor): skipping reference to missing attribute: 0
7:07:17 PM:     file: docs/modules/ROOT/pages/management-center-ldap.adoc
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM: [16:07:17.571] WARN (asciidoctor): skipping reference to missing attribute: 0
7:07:17 PM:     file: docs/modules/ROOT/pages/management-center-ldap.adoc
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM: [16:07:17.910] ERROR (asciidoctor): target of xref not found: hazelcast:computing:entry-processor.adoc
7:07:17 PM:     file: docs/modules/ROOT/pages/user-code-deployment.adoc
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM: [16:07:17.927] WARN (asciidoctor): unterminated listing block
7:07:17 PM:     file: docs/modules/ROOT/examples/map-ucn.yaml
7:07:17 PM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.12 | start path: docs)
7:07:17 PM:     stack:
7:07:17 PM:         file: docs/modules/ROOT/pages/user-code-namespaces.adoc:63
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e30ffb96a87b0008258a1f#L351