### PR TITLE
Fix build errors v/5.4

### DIFF
--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -3,41 +3,149 @@ site:
   url: http:localhost:5000
 content:
   sources:
-  - url: .
-    branches: HEAD
-    start_path: docs
-  - url: https://github.com/hazelcast/hazelcast-docs
-    branches: [main]
-    start_paths: [home,tutorials]
-  - url: https://github.com/hazelcast/imdg-docs
-    branches: [v/*]
-    start_path: docs
-  - url: https://github.com/hazelcast/hz-docs
-    branches: main
-    start_paths: [docs]
-  - url: https://github.com/hazelcast-guides/stream-to-stream-joins
-    branches: master
-    start_paths: docs
-  - url: https://github.com/hazelcast/management-center-docs
-    branches: [main]
-    start_path: docs
-  - url: https://github.com/hazelcast/cloud-docs
-    branches: [main]
-    start_paths: [docs, tutorials]
-  - url: https://github.com/hazelcast-guides/write-through-cache-mongodb-mapstore
-    branches: master
-    start_paths: docs
-  - url: https://github.com/hazelcast/hazelcast-cloud-maven-plugin
-    branches: main
-    start_path: docs
-  - url: https://github.com/hazelcast-guides/client-failover
-    branches: master
-    start_paths: docs
-  - url: https://github.com/hazelcast-guides/adoc-templates.git
-    branches: antora-doc
-  - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-external-backup-restore
-    branches: master
-    start_path: docs
+    - url: .
+      branches: HEAD
+      start_path: docs
+    - url: https://github.com/hazelcast/hazelcast-docs
+      start_paths: [home,tutorials]
+      branches: HEAD
+    - url: https://github.com/hazelcast/hz-docs
+      branches: [main, v/*]
+      start_path: docs
+    - url: https://github.com/hazelcast/imdg-docs
+      branches: [v/*]
+      start_path: docs
+    - url: https://github.com/hazelcast/imdg-docs
+      branches: [archived-versions]
+      start_paths: docs/*
+    - url: https://github.com/hazelcast/management-center-docs
+      branches: [main, v/*]
+      start_path: docs
+    - url: https://github.com/hazelcast/management-center-docs
+      branches: [archived-versions]
+      start_paths: docs/*
+    - url: https://github.com/hazelcast/cloud-docs
+      branches: [main]
+      start_paths: [docs, tutorials]
+    - url: https://github.com/hazelcast-guides/client-failover
+      branches: master
+      start_paths: docs
+    - url: https://github.com/hazelcast-guides/spring-boot-sample
+      branches: master
+      start_paths: docs
+    - url: https://github.com/hazelcast-guides/serverless-fraud-detection
+      branches: master
+      start_paths: docs
+    - url: https://github.com/hazelcast-guides/write-through-cache-mongodb-mapstore
+      branches: master
+      start_paths: docs
+    - url: https://github.com/hazelcast-guides/standard-deviation-parallel-processing
+      branches: master
+      start_paths: docs
+    - url: https://github.com/hazelcast-guides/stream-to-stream-joins
+      branches: master
+      start_paths: docs
+    - url: https://github.com/hazelcast/hazelcast-cloud-maven-plugin
+      branches: main
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/adoc-templates.git
+      branches: antora-doc
+    - url: https://github.com/hazelcast-guides/caching-springboot-jcache
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/hazelcast-embedded-springboot
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/springboot-hibernate
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/hibernate-jcache
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/istio
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/caching-micronaut
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/kubernetes-embedded
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/hazelcast-embedded-microprofile
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/hazelcast-client-quarkus
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/springboot-webfilter-session-replication
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/caching-springboot
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/ecs-embedded
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/striim-cdc
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/springboot-tomcat-session-replication
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/vmware-tanzu
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/terraform-quickstarts
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/kubernetes-external-client
+      branches: main
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/active-directory-authentication
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/kubernetes-sidecar
+      branches: main
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/kubernetes-hpa
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/kubernetes-ssl
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/kubernetes-wan
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/kubernetes
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/spring-session-hazelcast
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/ec2-cluster
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/linkerd
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/consul
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/nodejs-client-getting-started
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/go-client-getting-started
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/openfaas-hz-client
+      branches: master
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-expose-externally
+      branches: main
+      start_path: docs
+    - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-external-backup-restore
+      branches: master
+      start_path: docs
 ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -2,7 +2,7 @@ site:
   title: Documentation
   url: http:localhost:5000
 content:
-  sources: 
+  sources:
   - url: .
     branches: HEAD
     start_path: docs
@@ -24,9 +24,6 @@ content:
   - url: https://github.com/hazelcast/cloud-docs
     branches: [main]
     start_paths: [docs, tutorials]
-  - url: https://github.com/hazelcast/hazelcast-commandline-client
-    branches: main
-    start_path: docs
   - url: https://github.com/hazelcast-guides/write-through-cache-mongodb-mapstore
     branches: master
     start_paths: docs
@@ -41,7 +38,7 @@ content:
   - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-external-backup-restore
     branches: master
     start_path: docs
-ui: 
+ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
     snapshot: true

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -10,23 +10,20 @@ content:
       start_paths: [home,tutorials]
       branches: HEAD
     - url: https://github.com/hazelcast/hz-docs
-      branches: [main, v/*]
+      branches: [main]
       start_path: docs
     - url: https://github.com/hazelcast/imdg-docs
       branches: [v/*]
       start_path: docs
-    - url: https://github.com/hazelcast/imdg-docs
-      branches: [archived-versions]
-      start_paths: docs/*
     - url: https://github.com/hazelcast/management-center-docs
-      branches: [main, v/*]
+      branches: [main]
       start_path: docs
-    - url: https://github.com/hazelcast/management-center-docs
-      branches: [archived-versions]
-      start_paths: docs/*
     - url: https://github.com/hazelcast/cloud-docs
       branches: [main]
       start_paths: [docs, tutorials]
+    - url: https://github.com/hazelcast-guides/sql_stock_ticker_cloud
+      branches: master
+      start_paths: docs
     - url: https://github.com/hazelcast-guides/client-failover
       branches: master
       start_paths: docs
@@ -86,9 +83,6 @@ content:
     - url: https://github.com/hazelcast-guides/ecs-embedded
       branches: master
       start_path: docs
-    - url: https://github.com/hazelcast-guides/striim-cdc
-      branches: master
-      start_path: docs
     - url: https://github.com/hazelcast-guides/springboot-tomcat-session-replication
       branches: master
       start_path: docs
@@ -146,6 +140,9 @@ content:
     - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-external-backup-restore
       branches: master
       start_path: docs
+    - url: https://github.com/hazelcast/clc-docs
+      branches: main
+      start_path: docs
 ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
@@ -154,7 +151,7 @@ asciidoc:
   attributes:
     # Download images from kroki at build time (does not work for inline images)
     kroki-fetch-diagram: true
-    # Inlude next and previous links on each page
+    # Include next and previous links on each page
     page-pagination: true
     idprefix: ''
     # Separate anchor link names by dashes

--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -196,7 +196,7 @@ be deployed with the Hazelcast container in the same Pod.
 include::ROOT:example$/hazelcast-persistence-agent.yaml[]
 ----
 <1> The backup type for where the backup data will be stored. It is either `Local` or `External`. Default value is `Local`.
-<5> The agent which is responsible for backing data up into the external storage.
+<2> The agent which is responsible for backing data up into the external storage.
 The agent configuration is optional. If you set the `backupType` to `External` and do not pass the agent configuration, the operator
 directly use the latest stable version of the agent.
 +

--- a/docs/modules/ROOT/pages/migration-guide.adoc
+++ b/docs/modules/ROOT/pages/migration-guide.adoc
@@ -1,4 +1,4 @@
-= Migrating to 5.5
+=== Migrating to 5.5
 
 - `backupType` field is removed:
 

--- a/docs/modules/ROOT/pages/user-code-deployment.adoc
+++ b/docs/modules/ROOT/pages/user-code-deployment.adoc
@@ -20,7 +20,7 @@ Below are the configuration options for the User Code Deployment feature.
 |JAR files from an external bucket are placed under the Java classpath when the following parameter values are supplied:
 
   - `secret`: Name of the Secret object which holds the credentials for your cloud provider.
-  - `bucketURI`: Full path for the external bucket. For example: `gs://your-bucket/path/to/jars`. 
+  - `bucketURI`: Full path for the external bucket. For example: `gs://your-bucket/path/to/jars`.
 
 |`configMaps`
 |Files specified in the ConfigMaps are placed under the Java classpath.
@@ -34,8 +34,8 @@ Below are the configuration options for the User Code Deployment feature.
 
 The example configuration does the following:
 
-- Downloads JAR files from the specified external bucket and places them under the classpath of each of the Hazelcast members. 
-- Puts all the files specified in the ConfigMap objects under the classpath of each of the Hazelcast members. 
+- Downloads JAR files from the specified external bucket and places them under the classpath of each of the Hazelcast members.
+- Puts all the files specified in the ConfigMap objects under the classpath of each of the Hazelcast members.
 
 
 .Example configuration
@@ -80,7 +80,7 @@ Use the following configuration options in the `Map` resource for a MapStore. Th
 
 === Example MapStore Configuration
 
-An example `Map` resource with MapStore configuration. 
+An example `Map` resource with MapStore configuration.
 
 .Example configuration
 [source,yaml,subs="attributes+"]
@@ -103,7 +103,7 @@ There are three variants of the executor service:
 - Durable Executor Service
 - Scheduled Executor Service.
 
-Configuration options for a `Hazelcast` resource to work with all three variants are shown in this section, along with examples of how you might implement these options. For more detailed implementation information, see xref:hazelcast:computing:executor-service.adoc[Java Executor Service]. 
+Configuration options for a `Hazelcast` resource to work with all three variants are shown in this section, along with examples of how you might implement these options. For more detailed implementation information, see xref:hazelcast:computing:executor-service.adoc[Java Executor Service].
 
 
 [tabs]
@@ -219,4 +219,4 @@ include::ROOT:example$/hazelcast-scheduled-executor-service.yaml[]
 
 == Configuring an Entry Processor with Hazelcast Platform Operator
 
-An entry processor executes your code on a map entry in an atomic way. To implement the `EntryProcessor` interface, you can deploy an `EntryProcessor` class from the Hazelcast Platform Operator to the classpath of a Hazelcast member. See xref:hazelcast:computing:entry-processor.adoc[Entry Processor] for more detailed information.
+An entry processor executes your code on a map entry in an atomic way. To implement the `EntryProcessor` interface, you can deploy an `EntryProcessor` class from the Hazelcast Platform Operator to the classpath of a Hazelcast member. See xref:hazelcast:data-structures:entry-processor.adoc[Entry Processor] for more detailed information.


### PR DESCRIPTION
Fixes

```
11:26:44 AM: [08:26:44.075] WARN (asciidoctor): callout list item index: expected 2, got 5
11:26:44 AM:     file: docs/modules/ROOT/pages/backup-restore.adoc:216
11:26:44 AM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.4 | start path: docs)
11:26:44 AM: [08:26:44.226] WARN (asciidoctor): section title out of sequence: expected level 1, got level 3
11:26:44 AM:     file: docs/modules/ROOT/pages/migration-guide.adoc:13
11:26:44 AM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.4 | start path: docs)
11:26:44 AM: [08:26:44.228] WARN (asciidoctor): section title out of sequence: expected level 1, got level 3
11:26:44 AM:     file: docs/modules/ROOT/pages/migration-guide.adoc:19
11:26:44 AM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.4 | start path: docs)
11:26:44 AM: [08:26:44.229] WARN (asciidoctor): section title out of sequence: expected level 1, got level 3
11:26:44 AM:     file: docs/modules/ROOT/pages/migration-guide.adoc:27
11:26:44 AM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.4 | start path: docs)
11:26:44 AM: [08:26:44.230] WARN (asciidoctor): section title out of sequence: expected level 1, got level 3
11:26:44 AM:     file: docs/modules/ROOT/pages/migration-guide.adoc:33
11:26:44 AM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.4 | start path: docs)
11:26:44 AM: [08:26:44.232] WARN (asciidoctor): section title out of sequence: expected level 1, got level 3
11:26:44 AM:     file: docs/modules/ROOT/pages/migration-guide.adoc:42
11:26:44 AM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.4 | start path: docs)
11:26:44 AM: [08:26:44.233] WARN (asciidoctor): section title out of sequence: expected level 1, got level 3
11:26:44 AM:     file: docs/modules/ROOT/pages/migration-guide.adoc:48
11:26:44 AM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.4 | start path: docs)
11:26:44 AM: [08:26:44.326] ERROR (asciidoctor): target of xref not found: hazelcast:computing:entry-processor.adoc
11:26:44 AM:     file: docs/modules/ROOT/pages/user-code-deployment.adoc
11:26:44 AM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.4 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e7ea837de71a000837d1ea#L279