### PR TITLE
Fix build errors v/5.5

### DIFF
--- a/docs/modules/ROOT/pages/user-code-deployment.adoc
+++ b/docs/modules/ROOT/pages/user-code-deployment.adoc
@@ -20,7 +20,7 @@ Below are the configuration options for the User Code Deployment feature.
 |JAR files from an external bucket are placed under the Java classpath when the following parameter values are supplied:
 
   - `secret`: Name of the Secret object which holds the credentials for your cloud provider.
-  - `bucketURI`: Full path for the external bucket. For example: `gs://your-bucket/path/to/jars`. 
+  - `bucketURI`: Full path for the external bucket. For example: `gs://your-bucket/path/to/jars`.
 
 |`configMaps`
 |Files specified in the ConfigMaps are placed under the Java classpath.
@@ -34,8 +34,8 @@ Below are the configuration options for the User Code Deployment feature.
 
 The example configuration does the following:
 
-- Downloads JAR files from the specified external bucket and places them under the classpath of each of the Hazelcast members. 
-- Puts all the files specified in the ConfigMap objects under the classpath of each of the Hazelcast members. 
+- Downloads JAR files from the specified external bucket and places them under the classpath of each of the Hazelcast members.
+- Puts all the files specified in the ConfigMap objects under the classpath of each of the Hazelcast members.
 
 
 .Example configuration
@@ -80,7 +80,7 @@ Use the following configuration options in the `Map` resource for a MapStore. Th
 
 === Example MapStore Configuration
 
-An example `Map` resource with MapStore configuration. 
+An example `Map` resource with MapStore configuration.
 
 .Example configuration
 [source,yaml,subs="attributes+"]
@@ -103,7 +103,7 @@ There are three variants of the executor service:
 - Durable Executor Service
 - Scheduled Executor Service.
 
-Configuration options for a `Hazelcast` resource to work with all three variants are shown in this section, along with examples of how you might implement these options. For more detailed implementation information, see xref:hazelcast:computing:executor-service.adoc[Java Executor Service]. 
+Configuration options for a `Hazelcast` resource to work with all three variants are shown in this section, along with examples of how you might implement these options. For more detailed implementation information, see xref:hazelcast:computing:executor-service.adoc[Java Executor Service].
 
 
 [tabs]
@@ -219,4 +219,4 @@ include::ROOT:example$/hazelcast-scheduled-executor-service.yaml[]
 
 == Configuring an Entry Processor with Hazelcast Platform Operator
 
-An entry processor executes your code on a map entry in an atomic way. To implement the `EntryProcessor` interface, you can deploy an `EntryProcessor` class from the Hazelcast Platform Operator to the classpath of a Hazelcast member. See xref:hazelcast:computing:entry-processor.adoc[Entry Processor] for more detailed information.
+An entry processor executes your code on a map entry in an atomic way. To implement the `EntryProcessor` interface, you can deploy an `EntryProcessor` class from the Hazelcast Platform Operator to the classpath of a Hazelcast member. See xref:hazelcast:data-structures:entry-processor.adoc[Entry Processor] for more detailed information.


### PR DESCRIPTION
Fixes

```
11:26:44 AM: [08:26:44.884] ERROR (asciidoctor): target of xref not found: hazelcast:computing:entry-processor.adoc
11:26:44 AM:     file: docs/modules/ROOT/pages/user-code-deployment.adoc
11:26:44 AM:     source: https://github.com/hazelcast/hazelcast-platform-operator-docs (branch: v/5.5 | start path: docs)
```