### PR TITLE
DOCS-920: new navigation structure for docs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -7,7 +7,7 @@
 
 .Deploy
 // Deploy options
-* xref:get-started.adoc[Deploy a cluster]
+* xref:get-started.adoc[Deploy cluster]
 * xref:lite-members.adoc[Deploy Lite Members]
 * xref:deploy-management-center.adoc[Deploy Management Center]
 * xref:flow.adoc[Deploy Flow]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -17,7 +17,7 @@
 .Configure
 // Configuration options
 * xref:connect-outside-kubernetes.adoc[Connect to Hazelcast from outside Kubernetes]
-* xref:scheduling-configuration.adoc[Assign Pods to nodes]
+* xref:scheduling-configuration.adoc[Assign pods to nodes]
 
 * Memory & storage
 ** xref:native-memory.adoc[High-density memory store]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -23,8 +23,7 @@
 ** xref:native-memory.adoc[High-density memory store]
 ** xref:tiered-storage.adoc[Tiered storage]
 
-* Fault tolerance
-** xref:backup-restore.adoc[Backup & restore]
+* xref:backup-restore.adoc[Persistence, backup & restore]
 
 * Data
 ** Data structures

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -20,11 +20,11 @@
 * xref:scheduling-configuration.adoc[Assign Pods to nodes]
 
 * Memory & storage
-** xref:jvm-parameters.adoc[JVM parameters]
 ** xref:native-memory.adoc[High-density memory store]
 ** xref:tiered-storage.adoc[Tiered storage]
 
-* xref:backup-restore.adoc[Fault tolerance]
+* Fault tolerance
+** xref:backup-restore.adoc[Backup & restore]
 
 * Data
 ** Data structures
@@ -53,26 +53,27 @@
 *** xref:wan-replication.adoc[Configure WAN replication]
 *** xref:wan-sync.adoc[Synchronize WAN replicated data]
 
-** Security
-*** xref:tls.adoc[Configure TLS]
-*** xref:authorization.adoc[Authorization Methods to Access Cloud Storage]
+* Security
+** xref:tls.adoc[Configure TLS]
+** xref:authorization.adoc[Authorization Methods to Access Cloud Storage]
 
-** Compute
-*** xref:user-code-deployment.adoc[User Code Deployment]
-*** xref:user-code-namespaces.adoc[User Code Namespaces]
+* Compute
+** xref:user-code-deployment.adoc[User Code Deployment]
+** xref:user-code-namespaces.adoc[User Code Namespaces]
 
-** Config properties
-*** xref:env-vars.adoc[Environment variables]
-*** xref:resource-configuration.adoc[Container resources]
-*** xref:hazelcast-parameters.adoc[System properties]
-*** xref:custom-config.adoc[Custom configuration]
+* Configuration properties
+** xref:env-vars.adoc[Environment variables]
+** xref:resource-configuration.adoc[Container resources]
+** xref:hazelcast-parameters.adoc[System properties]
+** xref:custom-config.adoc[Custom configuration]
+** xref:jvm-parameters.adoc[JVM parameters]
 
-** Management Center
-*** xref:management-center-clusters.adoc[Hazelcast clusters]
-*** xref:management-center-external-access.adoc[External access]
-*** xref:management-center-persistence.adoc[Persistence]
-*** xref:management-center-jvm-args.adoc[JVM arguments]
-*** xref:management-center-ldap.adoc[LDAP security provider]
+* Management Center
+** xref:management-center-clusters.adoc[Hazelcast clusters]
+** xref:management-center-external-access.adoc[External access]
+** xref:management-center-persistence.adoc[Persistence]
+** xref:management-center-jvm-args.adoc[JVM arguments]
+** xref:management-center-ldap.adoc[LDAP security provider]
 
 .Reference
 // Other reference docs

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -8,7 +8,7 @@
 .Deploy
 // Deploy options
 * xref:get-started.adoc[Deploy cluster]
-* xref:lite-members.adoc[Deploy Lite Members]
+* xref:lite-members.adoc[Deploy lite members]
 * xref:deploy-management-center.adoc[Deploy Management Center]
 * xref:flow.adoc[Deploy Flow]
 * xref:air-gapped-env.adoc[Run in air-gapped environments]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,53 +1,80 @@
-.Get Started
+.Get started
+// Get started, release notes & support info
 * xref:index.adoc[Overview]
-* xref:ask-ai.adoc[]
-* xref:get-started.adoc[Deploy a Cluster]
+* xref:ask-ai.adoc[Ask AI]
+* xref:release-notes.adoc[Release notes]
+* xref:get-support.adoc[Get support]
+
+.Deploy
+// Deploy options
+* xref:get-started.adoc[Deploy a cluster]
+* xref:lite-members.adoc[Deploy Lite Members]
 * xref:deploy-management-center.adoc[Deploy Management Center]
-* xref:scaling-upgrading.adoc[Scaling & Upgrading]
-* xref:air-gapped-env.adoc[Running in air-gapped environments]
-* xref:connect-outside-kubernetes.adoc[]
-* xref:scheduling-configuration.adoc[Scheduling Hazelcast Pods]
-* xref:serialization-configuration.adoc[Serialization]
-* xref:scaling-upgrading.adoc[Scaling & Upgrading]
-* xref:lite-members.adoc[Deploying Lite Members]
-* xref:cp-subsystem.adoc[Enabling CP Subsystem]
-* xref:tiered-storage.adoc[Tiered Storage]
-* Configuring Data Structures
-** xref:map-configuration.adoc[Map]
-** xref:multimap-configuration.adoc[MultiMap]
-** xref:topic-configuration.adoc[Topic]
-** xref:queue-configuration.adoc[Queue]
-** xref:cache-configuration.adoc[Cache]
-** xref:vector-collection-configuration.adoc[Vector Collection]
-** xref:replicatedmap-configuration.adoc[ReplicatedMap]
-* xref:backup-restore.adoc[Persistence, Backup, and Restore]
-* xref:wan-replication.adoc[Configuring WAN Replication]
-* xref:wan-sync.adoc[Syncronizing WAN replicated data]
-* xref:user-code-deployment.adoc[User Code Deployment]
-* xref:high-availability-mode.adoc[High Availability Mode]
-* xref:native-memory.adoc[Native Memory]
-* xref:jvm-parameters.adoc[Configuring JVM Parameters]
-* xref:env-vars.adoc[Configuring Environment Variables]
-* xref:resource-configuration.adoc[Configuring Resource Limits]
-* xref:hazelcast-parameters.adoc[Configuring System Properties]
-* xref:advanced-networking.adoc[Advanced Networking]
-* xref:tls.adoc[Configuring TLS]
-* xref:user-code-namespaces.adoc[User Code Namespaces]
-* xref:authorization.adoc[Authorization Methods to Access Cloud Storage]
-* Data Pipelines
-** xref:jet-engine-configuration.adoc[Configuring the Jet Engine]
-** xref:jet-job-configuration.adoc[Running Data Pipelines]
-** xref:jet-job-snapshot.adoc[Saving the State of Data Pipelines]
-* xref:custom-config.adoc[Custom Configuration of Hazelcast cluster]
-* Management Center
-** xref:management-center-clusters.adoc[Hazelcast Clusters]
-** xref:management-center-external-access.adoc[External Access]
-** xref:management-center-persistence.adoc[Persistence]
-** xref:management-center-jvm-args.adoc[JVM Arguments]
-** xref:management-center-ldap.adoc[LDAP Security Provider]
-* xref:flow.adoc[Flow]
+* xref:flow.adoc[Deploy Flow]
+* xref:air-gapped-env.adoc[Run in air-gapped environments]
+* xref:scaling-upgrading.adoc[Scale and upgrade]
+
+.Configure
+// Configuration options
+* xref:connect-outside-kubernetes.adoc[Connect to Hazelcast from outside Kubernetes]
+* xref:scheduling-configuration.adoc[Assign Pods to nodes]
+
+* Memory & storage
+** xref:jvm-parameters.adoc[JVM parameters]
+** xref:native-memory.adoc[High-density memory store]
+** xref:tiered-storage.adoc[Tiered storage]
+
+* xref:backup-restore.adoc[Fault tolerance]
+
+* Data
+** Data structures
+*** xref:map-configuration.adoc[Map]
+*** xref:multimap-configuration.adoc[MultiMap]
+*** xref:topic-configuration.adoc[Topic]
+*** xref:queue-configuration.adoc[Queue]
+*** xref:cache-configuration.adoc[Cache]
+*** xref:vector-collection-configuration.adoc[Vector collection]
+*** xref:replicatedmap-configuration.adoc[ReplicatedMap]
+
+** Data pipelines
+*** xref:jet-engine-configuration.adoc[Configure the Jet Engine]
+*** xref:jet-job-configuration.adoc[Run data pipelines]
+*** xref:jet-job-snapshot.adoc[Save state of data pipelines]
+
+** xref:serialization-configuration.adoc[Data serialization]
+** xref:cp-subsystem.adoc[Enable CP subsystem]
+
+* Resilience
+** Partition groups & networking
+*** xref:high-availability-mode.adoc[High Availability Mode]
+*** xref:advanced-networking.adoc[Advanced network configuration]
+
+** Synchronize data across clusters
+*** xref:wan-replication.adoc[Configure WAN replication]
+*** xref:wan-sync.adoc[Synchronize WAN replicated data]
+
+** Security
+*** xref:tls.adoc[Configure TLS]
+*** xref:authorization.adoc[Authorization Methods to Access Cloud Storage]
+
+** Compute
+*** xref:user-code-deployment.adoc[User Code Deployment]
+*** xref:user-code-namespaces.adoc[User Code Namespaces]
+
+** Config properties
+*** xref:env-vars.adoc[Environment variables]
+*** xref:resource-configuration.adoc[Container resources]
+*** xref:hazelcast-parameters.adoc[System properties]
+*** xref:custom-config.adoc[Custom configuration]
+
+** Management Center
+*** xref:management-center-clusters.adoc[Hazelcast clusters]
+*** xref:management-center-external-access.adoc[External access]
+*** xref:management-center-persistence.adoc[Persistence]
+*** xref:management-center-jvm-args.adoc[JVM arguments]
+*** xref:management-center-ldap.adoc[LDAP security provider]
 
 .Reference
-// Configuration options/spec files/any other reference docs
-* xref:phone-homes.adoc[Phone Homes]
-* xref:api-ref.adoc[API References]
+// Other reference docs
+* xref:phone-homes.adoc[Phone home data]
+* xref:api-ref.adoc[API types]

--- a/docs/modules/ROOT/pages/get-support.adoc
+++ b/docs/modules/ROOT/pages/get-support.adoc
@@ -1,7 +1,7 @@
 = Get support
 :description: 'Getting support with Hazelcast Platform Operator.'
 
-Customer support is for paying Hazelcast customers. For further information on Hazelcast's comprehensive 24/7 support offerings, refer to the https://hazelcast.com/services/support/[Hazelcast website^].
+Customer support is for paying Hazelcast customers. For further information on Hazelcast's comprehensive 24/7 support offerings, refer to the https://hazelcast.com/services/support/?utm_source=docs-website[Hazelcast website^].
 
 A support subscription from Hazelcast allows you to get the most value from Hazelcast Platform Operator. Our rapid response times to technical
 support inquiries, access to critical software patches, and other services allow you to improve productivity and quality.

--- a/docs/modules/ROOT/pages/get-support.adoc
+++ b/docs/modules/ROOT/pages/get-support.adoc
@@ -1,0 +1,28 @@
+= Get support
+:description: 'Getting support with Hazelcast Platform Operator.'
+
+Customer support is for paying Hazelcast customers. For further information on Hazelcast's comprehensive 24/7 support offerings, refer to the https://hazelcast.com/services/support/[Hazelcast website^].
+
+A support subscription from Hazelcast allows you to get the most value from Hazelcast Platform Operator. Our rapid response times to technical
+support inquiries, access to critical software patches, and other services allow you to improve productivity and quality.
+
+When you have an account set up, you can https://support.hazelcast.com/s/[open a support request].
+
+When submitting a ticket to the team, provide the following information:
+
+* *A clear summary of the issue*. Add this in the title of your issue to help the team to direct the issue to the right expert.
+* *The steps to take to reproduce the issue*, if possible. If you aren't sure, describe the sequence of events that led to the problem. Your test case, or use case is also very helpful.
+* *A full description of the problem and any error* that was encountered. Your test and use cases can provide us with guidance on where we need to focus our investigations. Include the time at which you encountered the issue.
+* *Hazelcast Logs*. Ensure that all your environments capture Hazelcast diagnostics logs, which we will use to diagnose your issues. If your environments are not capturing diagnostics logs, update them and capture diagnostics logs before opening the ticket. Do not truncate the diagnostic logs. The process, health monitoring, and networking logs also contain useful information, and should be attached along with the diagnostic logs when you open a ticket. Ensure that system and environment details captured at system startup are included, even in truncated logs, and that the provided logs include entries for the time at which you encountered the issue. 
+* *Relevant screenshots and/or error messages*.
+* *Thread dumps for all members*.
+* *Heap dumps*.
+* *The severity of the issue*, as follows:
+
+** `PROD` issues affecting production: severity 1.
+
+** `DEV` issues: severity 3 and priority low.
+
+** Other issues, such as questions or documentation feedback: severity 2 or 3 depending on severity.
+
+The more information that you can provide, the faster Hazelcast Customer Support can respond to your issue. Hazelcast appreciates your help and timely response to any further communication. 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -45,38 +45,6 @@ Short discussion of the difference between the Helm chart and the operator
 Known limitations
 ////
 
-== Customer Support
-
-Customer support is for paying Hazelcast customers. For further information on Hazelcast's comprehensive 24/7 support offerings, refer to the https://hazelcast.com/services/support/[Hazelcast website^].
-
-A support subscription from Hazelcast allows you to get the most value from Hazelcast Platform Operator. Our rapid response times to technical
-support inquiries, access to critical software patches, and other services allow you to improve productivity and quality.
-
-When you have an account set up, you can https://support.hazelcast.com/s/[open a support request].
-
-When submitting a ticket to the team, provide the following information:
-
-* *A clear summary of the issue*. Add this in the title of your issue to help the team to direct the issue to the right expert.
-* *The steps to take to reproduce the issue*, if possible. If you aren't sure, describe the sequence of events that led to the problem. Your test case, or use case is also very helpful.
-* *A full description of the problem and any error* that was encountered. Your test and use cases can provide us with guidance on where we need to focus our investigations. Include the time at which you encountered the issue.
-* *Hazelcast Logs*. Ensure that all your environments capture Hazelcast diagnostics logs, which we will use to diagnose your issues. If your environments are not capturing diagnostics logs, update them and capture diagnostics logs before opening the ticket. Do not truncate the diagnostic logs. The process, health monitoring, and networking logs also contain useful information, and should be attached along with the diagnostic logs when you open a ticket. Ensure that system and environment details captured at system startup are included, even in truncated logs, and that the provided logs include entries for the time at which you encountered the issue. 
-* *Relevant screenshots and/or error messages*.
-* *Thread dumps for all members*.
-* *Heap dumps*.
-* *The severity of the issue*, as follows:
-
-** `PROD` issues affecting production: severity 1.
-
-** `DEV` issues: severity 3 and priority low.
-
-** Other issues, such as questions or documentation feedback: severity 2 or 3 depending on severity.
-
-The more information that you can provide, the faster Hazelcast Customer Support can respond to your issue. Hazelcast appreciates your help and timely response to any further communication. 
-
-== Getting Started
+== Get Started
 
 xref:get-started.adoc[].
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "@antora/cli": "^3.1.1",
     "@antora/site-generator": "^3.1.1",
     "@jcahills/antora-link-checker": "^1.0.1",
-    "ngrok": "^3.3.0",
-    "serve": "^11.3.2",
-    "asciidoctor-kroki": "^0.10.0"
+    "asciidoctor-kroki": "^0.10.0",
+    "ngrok": "^5.0.0-beta.2",
+    "serve": "^14.2.4"
   }
 }


### PR DESCRIPTION
Updated the navigation structure as agreed in https://hazelcast.atlassian.net/browse/DOCS-920, with feedback from Hasan and Avtar (please see Google sheet attached to docs Jira ticket). This chunks the Operator topics into Deploy and Configure tasks to make it easier for readers to locate information, and to mirror the structure of other doc sets (e.g. Platform). 

The headings and subheadings use sentence case (first letter capitalised) and avoid gerunds (-ing words), in-keeping with the HZC style guide.

A new 'Get support' topic has also been created, in line with what we have in other doc sets.