### PR TITLE
HZX-343-remove-toggle-in-doc: removed fields from yaml file

### DIFF
--- a/docs/modules/ROOT/examples/flow.yaml
+++ b/docs/modules/ROOT/examples/flow.yaml
@@ -23,7 +23,5 @@ spec:
   - name: OPTIONS
     value: |
       --flow.analytics.persistRemoteCallResponses=true
-      --flow.stream-server.enabled=false
       --flow.analytics.persistResults=false
-      --flow.toggles.dashboard-enabled=true
       --flow.config.custom.managementCenterUrl=http://233.252.0.158/mc


### PR DESCRIPTION
Removed the toggle fields from the yaml file that is used to create the example code snippet