### PR TITLE
Fix `backport` label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,7 +19,7 @@ jobs:
         branch: ${{ fromJSON(needs.get-maintenance-branches.outputs.branches) }}
     uses: hazelcast/hz-docs/.github/workflows/backport-workflow.yml@main
     with:
-      label-to-check-for: '["backport to all versions"]'
+      label-to-check-for: '["backport"]'
       target-branch: v/${{ matrix.branch }}
     secrets: inherit
 


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-platform-operator-docs/pull/266 the ation was updated but the wrong label was being checked for, it should be looking for `backport` as originally introduced in https://github.com/hazelcast/hazelcast-platform-operator-docs/pull/4