### PR TITLE
Remove `docs.hazelcast.com` links

### DIFF
--- a/docs/modules/ROOT/pages/advanced-networking.adoc
+++ b/docs/modules/ROOT/pages/advanced-networking.adoc
@@ -1,6 +1,6 @@
 = Advanced Network Configuration
 
-In Hazelcast, you can configure Hazelcast members with separate server sockets, applying distinct network configurations for various protocols. This feature is known as the  link:https://docs.hazelcast.com/hazelcast/latest/clusters/network-configuration#advanced-network-configuration[Advanced Network] and it supports Member, Client, REST, Memcache, and WAN protocols.
+In Hazelcast, you can configure Hazelcast members with separate server sockets, applying distinct network configurations for various protocols. This feature is known as the  xref:{page-latest-supported-hazelcast}@hazelcast:clusters:network-configuration#advanced-network-configuration.adoc[Advanced Network] and it supports Member, Client, REST, Memcache, and WAN protocols.
 
 In the Hazelcast Platform Operator, advanced networking configuration is enabled by default, and certain protocol properties are pre-configured:
 

--- a/docs/modules/ROOT/pages/api-ref.adoc
+++ b/docs/modules/ROOT/pages/api-ref.adoc
@@ -269,8 +269,8 @@ m| resources | Compute Resources required by the Agent container. m| &#42;https:
 [cols="4,8,4,2,4"options="header"]
 |===
 | Field | Description | Type | Required | Default
-m| name | Name of the attribute xref:{page-latest-supported-hazelcast}@hazelcast:query:predicate-overview.adoc#creating-custom-query-attributes m| string | true | -
-m| extractorClassName | Name of the extractor class xref:{page-latest-supported-hazelcast}@hazelcast:query:predicate-overview.adoc#implementing-a-valueextractor m| string | true | -
+m| name | Name of the attribute xref:{page-latest-supported-hazelcast}@hazelcast:query:predicate-overview.adoc#creating-custom-query-attributes[] m| string | true | -
+m| extractorClassName | Name of the extractor class xref:{page-latest-supported-hazelcast}@hazelcast:query:predicate-overview.adoc#implementing-a-valueextractor[] m| string | true | -
 |===
 
 <<Table of Contents,Back to TOC>>

--- a/docs/modules/ROOT/pages/api-ref.adoc
+++ b/docs/modules/ROOT/pages/api-ref.adoc
@@ -269,8 +269,8 @@ m| resources | Compute Resources required by the Agent container. m| &#42;https:
 [cols="4,8,4,2,4"options="header"]
 |===
 | Field | Description | Type | Required | Default
-m| name | Name of the attribute https://docs.hazelcast.com/hazelcast/latest/query/predicate-overview#creating-custom-query-attributes m| string | true | -
-m| extractorClassName | Name of the extractor class https://docs.hazelcast.com/hazelcast/latest/query/predicate-overview#implementing-a-valueextractor m| string | true | -
+m| name | Name of the attribute xref:{page-latest-supported-hazelcast}@hazelcast:query:predicate-overview.adoc#creating-custom-query-attributes m| string | true | -
+m| extractorClassName | Name of the extractor class xref:{page-latest-supported-hazelcast}@hazelcast:query:predicate-overview.adoc#implementing-a-valueextractor m| string | true | -
 |===
 
 <<Table of Contents,Back to TOC>>
@@ -991,10 +991,10 @@ m| resources | Compute Resources required by the Hazelcast container. m| &#42;ht
 m| persistence | Persistence configuration m| &#42;<<HazelcastPersistenceConfiguration,HazelcastPersistenceConfiguration>> | false | -
 m| agent | B&R Agent configurations m| <<AgentConfiguration,AgentConfiguration>> | false | {repository: "docker.io/hazelcast/platform-operator-agent", version: "latest-snapshot"}
 m| jet | Jet Engine configuration m| &#42;<<JetEngineConfiguration,JetEngineConfiguration>> | false | {enabled: true, resourceUploadEnabled: false}
-m| executorServices | Java Executor Service configurations, see https://docs.hazelcast.com/hazelcast/latest/computing/executor-service m| []<<ExecutorServiceConfiguration,ExecutorServiceConfiguration>> | false | -
-m| durableExecutorServices | Durable Executor Service configurations, see https://docs.hazelcast.com/hazelcast/latest/computing/durable-executor-service m| []<<DurableExecutorServiceConfiguration,DurableExecutorServiceConfiguration>> | false | -
-m| scheduledExecutorServices | Scheduled Executor Service configurations, see https://docs.hazelcast.com/hazelcast/latest/computing/scheduled-executor-service m| []<<ScheduledExecutorServiceConfiguration,ScheduledExecutorServiceConfiguration>> | false | -
-m| properties | Hazelcast system properties, see https://docs.hazelcast.com/hazelcast/latest/system-properties m| map[string]string | false | -
+m| executorServices | Java Executor Service configurations, see xref:{page-latest-supported-hazelcast}@hazelcast:computing:executor-service.adoc[] m| []<<ExecutorServiceConfiguration,ExecutorServiceConfiguration>> | false | -
+m| durableExecutorServices | Durable Executor Service configurations, see xref:{page-latest-supported-hazelcast}@hazelcast:computing:durable-executor-service.adoc[] m| []<<DurableExecutorServiceConfiguration,DurableExecutorServiceConfiguration>> | false | -
+m| scheduledExecutorServices | Scheduled Executor Service configurations, see xref:{page-latest-supported-hazelcast}@hazelcast:computing:scheduled-executor-service.adoc[] m| []<<ScheduledExecutorServiceConfiguration,ScheduledExecutorServiceConfiguration>> | false | -
+m| properties | Hazelcast system properties, see xref:{page-latest-supported-hazelcast}@hazelcast::system-properties.adoc[] m| map[string]string | false | -
 m| loggingLevel | Logging level for Hazelcast members m| <<LoggingLevel,LoggingLevel>> | false | "INFO"
 m| highAvailabilityMode | Configuration to create clusters resilient to node and zone failures m| <<HighAvailabilityMode,HighAvailabilityMode>> | false | -
 m| jvm | Hazelcast JVM configuration m| &#42;<<JVMConfiguration,JVMConfiguration>> | false | -
@@ -1128,9 +1128,9 @@ m| spec | Specification of the desired behavior of the hot backup. m| <<HotBacku
 |===
 | Field | Description | Type | Required | Default
 m| name | Name of the index config. m| string | false | -
-m| type | Type of the index. See https://docs.hazelcast.com/hazelcast/latest/query/indexing-maps#index-types m| <<IndexType,IndexType>> | true | -
+m| type | Type of the index. See xref:{page-latest-supported-hazelcast}@hazelcast:query:indexing-maps.adoc#index-types[] m| <<IndexType,IndexType>> | true | -
 m| attributes | Attributes of the index. m| []string | false | -
-m| bitMapIndexOptions | Options for "BITMAP" index type. See https://docs.hazelcast.com/hazelcast/latest/query/indexing-maps#configuring-bitmap-indexes m| &#42;<<BitmapIndexOptionsConfig,BitmapIndexOptionsConfig>> | false | -
+m| bitMapIndexOptions | Options for "BITMAP" index type. See xref:{page-latest-supported-hazelcast}@hazelcast:query:indexing-maps.adoc#configuring-bitmap-indexes[] m| &#42;<<BitmapIndexOptionsConfig,BitmapIndexOptionsConfig>> | false | -
 |===
 
 <<Table of Contents,Back to TOC>>
@@ -1617,12 +1617,12 @@ m| userCodeNamespace | Name of the User Code Namespace applied to this instance 
 m| timeToLiveSeconds | Maximum time in seconds for each entry to stay in the map. If it is not 0, entries that are older than this time and not updated for this time are evicted automatically. It can be updated. m| int32 | false | 0
 m| maxIdleSeconds | Maximum time in seconds for each entry to stay idle in the map. Entries that are idle for more than this time are evicted automatically. It can be updated. m| int32 | false | 0
 m| eviction | Configuration for removing data from the map when it reaches its max size. It can be updated. m| <<EvictionConfig,EvictionConfig>> | false | {maxSize: 0, evictionPolicy: NONE, maxSizePolicy: PER_NODE}
-m| indexes | Indexes to be created for the map data. You can learn more at https://docs.hazelcast.com/hazelcast/latest/query/indexing-maps. It cannot be updated after map config is created successfully. m| []<<IndexConfig,IndexConfig>> | false | -
-m| attributes | Attributes to be used with Predicates API. You can learn more at https://docs.hazelcast.com/hazelcast/latest/query/predicate-overview#creating-custom-query-attributes m| []<<AttributeConfig,AttributeConfig>> | false | -
+m| indexes | Indexes to be created for the map data. You can learn more at xref:{page-latest-supported-hazelcast}@hazelcast:query:indexing-maps.adoc[]. It cannot be updated after map config is created successfully. m| []<<IndexConfig,IndexConfig>> | false | -
+m| attributes | Attributes to be used with Predicates API. You can learn more at xref:{page-latest-supported-hazelcast}@hazelcast:query:predicate-overview.adoc#creating-custom-query-attributes[] m| []<<AttributeConfig,AttributeConfig>> | false | -
 m| persistenceEnabled | When enabled, map data will be persisted. It cannot be updated after map config is created successfully. m| bool | false | false
-m| mapStore | Configuration options when you want to load/store the map entries from/to a persistent data store such as a relational database You can learn more at https://docs.hazelcast.com/hazelcast/latest/data-structures/working-with-external-data m| &#42;<<MapStoreConfig,MapStoreConfig>> | false | -
+m| mapStore | Configuration options when you want to load/store the map entries from/to a persistent data store such as a relational database You can learn more at xref:{page-latest-supported-hazelcast}@hazelcast:data-structures:working-with-external-data.adoc[] m| &#42;<<MapStoreConfig,MapStoreConfig>> | false | -
 m| inMemoryFormat | InMemoryFormat specifies in which format data will be stored in your map m| <<InMemoryFormatType,InMemoryFormatType>> | false | BINARY
-m| entryListeners | EntryListeners contains the configuration for the map-level or entry-based events listeners provided by the Hazelcast’s eventing framework. You can learn more at https://docs.hazelcast.com/hazelcast/latest/events/object-events. m| []<<EntryListenerConfiguration,EntryListenerConfiguration>> | false | -
+m| entryListeners | EntryListeners contains the configuration for the map-level or entry-based events listeners provided by the Hazelcast’s eventing framework. You can learn more at xref:{page-latest-supported-hazelcast}@hazelcast:events:object-events.adoc[]. m| []<<EntryListenerConfiguration,EntryListenerConfiguration>> | false | -
 m| nearCache | InMemoryFormat specifies near cache configuration for map m| &#42;<<NearCache,NearCache>> | false | -
 m| eventJournal | EventJournal specifies event journal configuration of the Map m| &#42;<<EventJournal,EventJournal>> | false | -
 m| tieredStore | TieredStore enables the Hazelcast's Tiered-Store feature for the Map m| &#42;<<TieredStore,TieredStore>> | false | -
@@ -1880,7 +1880,7 @@ m| asyncBackupCount | Number of asynchronous backups. m| int32 | false | 0
 m| userCodeNamespace | Name of the User Code Namespace applied to this instance m| string | false | -
 m| maxSize | Max size of the queue. m| int32 | false | 0
 m| emptyQueueTTLSeconds | Time in seconds after which the Queue will be destroyed if it stays empty or unused. If the values is not provided the Queue will never be destroyed. m| &#42;int32 | false | -1
-m| priorityComparatorClassName | The name of the comparator class. If the class name is provided, the Queue becomes Priority Queue. You can learn more at https://docs.hazelcast.com/hazelcast/latest/data-structures/priority-queue. m| string | false | -
+m| priorityComparatorClassName | The name of the comparator class. If the class name is provided, the Queue becomes Priority Queue. You can learn more at xref:{page-latest-supported-hazelcast}@hazelcast:data-structures:priority-queue.adoc[]. m| string | false | -
 |===
 
 <<Table of Contents,Back to TOC>>

--- a/docs/modules/ROOT/pages/backup-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-restore.adoc
@@ -236,7 +236,7 @@ NOTE: Agent copies the backup to be restored from `\{baseDir}/\{backupDir}/\{bac
 
 === Data Recovery Timeout
 
-To choose a data recovery timeout, you can use dataRecoveryTimeout. The field takes an integer value representing the timeout in seconds and uses this value to set link:https://docs.hazelcast.com/hazelcast/latest/storage/configuring-persistence#global-persistence-options[validation-timeout-seconds, data-load-timeout-seconds] Hazelcast Persistence options.
+To choose a data recovery timeout, you can use dataRecoveryTimeout. The field takes an integer value representing the timeout in seconds and uses this value to set xref:{page-latest-supported-hazelcast}@hazelcast:storage:configuring-persistence.adoc#global-persistence-options[validation-timeout-seconds, data-load-timeout-seconds] Hazelcast Persistence options.
 
 [source,yaml,subs="attributes+"]
 ----

--- a/docs/modules/ROOT/pages/configure-jaas.adoc
+++ b/docs/modules/ROOT/pages/configure-jaas.adoc
@@ -7,5 +7,5 @@ Hazelcast Operator supports JAAS-based authentication. JAAS (Java Authentication
 
 You can use Hazelcast Operator to configure JAAS-based authentication. To do this, configure `realms.jaas` in the Security section of the Hazelcast CR. For more information, see xref:api-ref.adoc#security[API types].
 
-For more information about using JAAS in Hazelcast, see link:https://docs.hazelcast.com/hazelcast/latest/security/jaas-authentication[JAAS authentication].
+For more information about using JAAS in Hazelcast, see xref:{page-latest-supported-hazelcast}@hazelcast:security:jaas-authentication.adoc[JAAS authentication].
 

--- a/docs/modules/ROOT/pages/hazelcast-parameters.adoc
+++ b/docs/modules/ROOT/pages/hazelcast-parameters.adoc
@@ -1,10 +1,10 @@
 = Configuring System Properties
 
-You can configure Hazelcast parameters using the `properties` field in the CRD spec. You can find all properties in link:https://docs.hazelcast.com/hazelcast/latest/system-properties[System Properties] document.
+You can configure Hazelcast parameters using the `properties` field in the CRD spec. You can find all properties in xref:{page-latest-supported-hazelcast}@hazelcast::system-properties.adoc[System Properties] document.
 
 It is worth highlighting the following system properties:
 
-- During a rolling upgrade, the cluster is shutdown gracefully to prevent data loss. You can configure this using the link:https://docs.hazelcast.com/hazelcast/latest/system-properties#hazelcast.graceful.shutdown.max.wait[hazelcast.graceful.shutdown.max.wait system property].
+- During a rolling upgrade, the cluster is shutdown gracefully to prevent data loss. You can configure this using the xref:{page-latest-supported-hazelcast}@hazelcast::system-properties.adoc#hazelcast.graceful.shutdown.max.wait[hazelcast.graceful.shutdown.max.wait system property].
 +
 Example Configuration:
 +
@@ -15,6 +15,6 @@ include::ROOT:example$/properties.yaml[]
 
 Hazelcast Platform Operator sets the following system properties to the default values, which cannot be changed:
 
-- The final step in the link:https://docs.hazelcast.com/hazelcast/latest/maintain-cluster/rolling-upgrades#rolling-upgrade-procedure[rolling upgrade procedure] is to trigger a rolling upgrade on the cluster. Hazelcast Platform Operator triggers it automatically by setting `hazelcast.cluster.version.auto.upgrade.enabled` to `true` by default.
+- The final step in the xref:{page-latest-supported-hazelcast}@hazelcast:maintain-cluster:rolling-upgrades.adoc#rolling-upgrade-procedure[rolling upgrade procedure] is to trigger a rolling upgrade on the cluster. Hazelcast Platform Operator triggers it automatically by setting `hazelcast.cluster.version.auto.upgrade.enabled` to `true` by default.
 
 - `hazelcast.persistence.auto.cluster.state` set to `true` by default.

--- a/docs/modules/ROOT/pages/jvm-parameters.adoc
+++ b/docs/modules/ROOT/pages/jvm-parameters.adoc
@@ -54,7 +54,7 @@ include::ROOT:example$/jvm_gc_logging.yaml[]
 It is going to set the following JVM argument: `-verbose:gc`
 
 === Setting the Garbage Collector
-WARNING: Before making Garbage Collector related changes using the Hazelcast Platform Operator, it is highly recommended to read link:https://docs.hazelcast.com/hazelcast/latest/capacity-planning#garbage-collection-considerations[Garbage Collector Considerations section of Capacity Planning Document] to decide which Garbage Collector to use.
+WARNING: Before making Garbage Collector related changes using the Hazelcast Platform Operator, it is highly recommended to read xref:{page-latest-supported-hazelcast}@hazelcast::capacity-planning.adoc#garbage-collection-considerations[Garbage Collector Considerations section of Capacity Planning Document] to decide which Garbage Collector to use.
 
 To set the Garbage Collector, following configuration can be used:
 

--- a/docs/modules/ROOT/pages/lite-members.adoc
+++ b/docs/modules/ROOT/pages/lite-members.adoc
@@ -1,6 +1,6 @@
 = Deploying Lite Members
 
-Use the Hazelcast Platform Operator to deploy link:https://docs.hazelcast.com/hazelcast/latest/maintain-cluster/lite-members[Lite Members]. You can use the separate `liteMember` section in the xref:api-ref.adoc#litemember[Hazelcast CR].
+Use the Hazelcast Platform Operator to deploy xref:{page-latest-supported-hazelcast}@hazelcast:maintain-cluster:lite-members.adoc[Lite Members]. You can use the separate `liteMember` section in the xref:api-ref.adoc#litemember[Hazelcast CR].
 
 WARNING: When `jvm`, `env`, `resources`, `scheduling` sections are configured in the Hazelcast CR, it will not affect the lite member configuration. Lite members must be configured as explained in the following sections.
 

--- a/docs/modules/ROOT/pages/management-center-ldap.adoc
+++ b/docs/modules/ROOT/pages/management-center-ldap.adoc
@@ -5,7 +5,7 @@
 
 Hazelcast supports authentication and authorization against Lightweight Directory Access Protocol (LDAP) servers.
 You can use Hazelcast Operator to configure Management Center to use an LDAP server. 
-For more information about using LDAP in the Management Center, see the link:https://docs.hazelcast.com/management-center/latest/deploy-manage/ldap[Management Center Documentation].
+For more information about using LDAP in the Management Center, see the xref:{page-latest-supported-mc}@management-center:deploy-manage:ldap.adoc[Management Center Documentation].
 
 == Setting Up the LDAP security provider
 

--- a/docs/modules/ROOT/pages/map-configuration.adoc
+++ b/docs/modules/ROOT/pages/map-configuration.adoc
@@ -45,7 +45,7 @@ Below are the configuration options for the `Map` resource. You can find more de
 NOTE: Persistence should be enabled for Hazelcast before enabling it for the map. You can learn about enabling persistence for Hazelcast in xref:backup-restore.adoc#enabling-persistence[Persistence, Backup and Restore].
 
 |mapStore
-|Configuration options when you want to load/store the map entries from/to a persistent data store such as a relational database. You can learn more at link:https://docs.hazelcast.com/hazelcast/latest/data-structures/working-with-external-data[Working With External Data].
+|Configuration options when you want to load/store the map entries from/to a persistent data store such as a relational database. You can learn more at xref:{page-latest-supported-hazelcast}@hazelcast:data-structures:working-with-external-data.adoc[Working With External Data].
 
 - className: Name of your class implementing MapLoader and/or MapStore interface.
 - initialMode: Sets the initial entry loading mode.
@@ -55,14 +55,14 @@ NOTE: Persistence should be enabled for Hazelcast before enabling it for the map
 - propertiesSecretName: Name of the secret holding the properties for the MapStore classes implementing the `MapLoaderLifecycleSupport` interface.
 
 |entryListeners
-|Configuration options for listening for the map-level or entry-based events using the listeners provided by the Hazelcast’s eventing framework. You can learn more at link:https://docs.hazelcast.com/hazelcast/latest/events/object-events[Distributed Object Events].
+|Configuration options for listening for the map-level or entry-based events using the listeners provided by the Hazelcast’s eventing framework. You can learn more at xref:{page-latest-supported-hazelcast}@hazelcast:events:object-events.adoc[Distributed Object Events].
 
 - className: Name of your class implementing a `MapListener` sub-interface.
 - includeValues: An optional attribute that indicates whether the map event should contains the map value.
 - local: An optional attribute that indicates whether you can listen to the map on the local member.
 
 |nearCache
-|Configuration options for server side `Near Cache`. You can learn more at link:https://docs.hazelcast.com/hazelcast/latest/cluster-performance/best-practices#near-cache[Near Cache].
+|Configuration options for server side `Near Cache`. You can learn more at xref:{page-latest-supported-hazelcast}@hazelcast:cluster-performance:best-practices.adoc#near-cache[Near Cache].
 
 - name: name of the near cache.
 - inMemoryFormat: specifies in which format data will be stored in your near cache.

--- a/docs/modules/tutorials/pages/operator-tutorial-expose-externally.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-expose-externally.adoc
@@ -101,7 +101,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the cluster config to the CLC:
 
@@ -369,7 +369,7 @@ Configure the Hazelcast client to connect to the cluster external address.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the cluster config to the CLC:
 

--- a/docs/modules/tutorials/pages/operator-tutorial-external-backup-restore.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-external-backup-restore.adoc
@@ -137,7 +137,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the cluster config to the CLC:
 

--- a/docs/modules/tutorials/pages/operator-tutorial-tls.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-tls.adoc
@@ -120,7 +120,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the cluster config to the CLC:
 

--- a/docs/modules/tutorials/pages/operator-tutorial-wan-replication.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-wan-replication.adoc
@@ -140,7 +140,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the first cluster config to the CLC:
 

--- a/docs/modules/tutorials/pages/operator-tutorial-wan-sync.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-wan-sync.adoc
@@ -107,7 +107,7 @@ EOF
 +
 [NOTE]
 ====
-Unsure of whether you need Full or Delta? See https://docs.hazelcast.com/hazelcast/5.5/wan/advanced-features#synchronizing-wan-target-cluster[Full WAN Synchronization] and https://docs.hazelcast.com/hazelcast/5.5/wan/advanced-features#delta-wan-synchronization[Delta WAN Synchronization] for details.
+Unsure of whether you need Full or Delta? See xref:{page-latest-supported-hazelcast}@hazelcast:wan:advanced-features.adoc#synchronizing-wan-target-cluster[Full WAN Synchronization] and xref:{page-latest-supported-hazelcast}@hazelcast:wan:advanced-features.adoc#delta-wan-synchronization[Delta WAN Synchronization] for details.
 ====
 
 . Find the address of the first cluster.
@@ -144,7 +144,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the first cluster config to the CLC:
 [source, bash]


### PR DESCRIPTION
Within our own documentation, links should be relative to follow versions and to improve compile-time checks.

See https://github.com/hazelcast/hz-docs/pull/1694