### PR TITLE
Use `latest` CLC URL

### DIFF
--- a/docs/modules/tutorials/pages/operator-tutorial-expose-externally.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-expose-externally.adoc
@@ -101,7 +101,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the cluster config to the CLC:
 
@@ -369,7 +369,7 @@ Configure the Hazelcast client to connect to the cluster external address.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the cluster config to the CLC:
 

--- a/docs/modules/tutorials/pages/operator-tutorial-external-backup-restore.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-external-backup-restore.adoc
@@ -137,7 +137,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the cluster config to the CLC:
 

--- a/docs/modules/tutorials/pages/operator-tutorial-tls.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-tls.adoc
@@ -120,7 +120,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the cluster config to the CLC:
 

--- a/docs/modules/tutorials/pages/operator-tutorial-wan-replication.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-wan-replication.adoc
@@ -140,7 +140,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the first cluster config to the CLC:
 

--- a/docs/modules/tutorials/pages/operator-tutorial-wan-sync.adoc
+++ b/docs/modules/tutorials/pages/operator-tutorial-wan-sync.adoc
@@ -144,7 +144,7 @@ The sample code (excluding CLC) for this tutorial is in the link:https://github.
 CLC::
 +
 --
-NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/5.5.0/install-clc[CLC installation instructions].
+NOTE: CLC must be installed in your system. See the https://docs.hazelcast.com/clc/latest/install-clc[CLC installation instructions].
 
 Add the first cluster config to the CLC:
 [source, bash]


### PR DESCRIPTION
Avoid hardcoding a version reference that will become outdated.