### PR TITLE
Remove explicit cURL `POST`

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger build
-      run: curl -X POST -d {} https://api.netlify.com/build_hooks/61bc88be7456f117b42186eb
+      run: curl -d {} https://api.netlify.com/build_hooks/61bc88be7456f117b42186eb


### PR DESCRIPTION
When executed with `verbose`, cURL logs:
> Note: Unnecessary use of -X or --request, POST is already inferred.

[The `-d`/`--data` flag sends data via `POST`](https://curl.se/docs/manpage.html#-d) so specifying `POST` _as well_ is redundant.