### PR TITLE
Move to Hazelcast 6.0 development cycle

### DIFF
--- a/docs/modules/ROOT/pages/api-ref.adoc
+++ b/docs/modules/ROOT/pages/api-ref.adoc
@@ -948,7 +948,7 @@ HazelcastSpec defines the desired state of Hazelcast
 | Field | Description | Type | Required | Default
 m| clusterSize | Number of Hazelcast members in the cluster. m| &#42;int32 | false | 3
 m| repository | Repository to pull the Hazelcast Platform image from. m| string | false | "docker.io/hazelcast/hazelcast-enterprise"
-m| version | Version of Hazelcast Platform. m| string | false | "5.8.0-SNAPSHOT"
+m| version | Version of Hazelcast Platform. m| string | false | "6.0.0-SNAPSHOT"
 m| imagePullPolicy | Pull policy for the Hazelcast Platform image m| https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#pullpolicy-v1-core[corev1.PullPolicy] | false | "IfNotPresent"
 m| imagePullSecrets | Image pull secrets for the Hazelcast Platform image m| []https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#localobjectreference-v1-core[corev1.LocalObjectReference] | false | -
 m| licenseKeySecretName | Name of the secret with Hazelcast Enterprise License Key. m| string | true | -


### PR DESCRIPTION
Hazelcast is being updated to the next MAJOR development cycle `5.8.0 -> 6.0.0`
See  https://github.com/hazelcast/hazelcast-mono/pull/7393