### PR TITLE
Add info about sidecar agent and logs [INBOX-1012]

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -84,6 +84,9 @@
 
 * xref:limitations.adoc[Limitations]
 
+.Troubleshoot
+* xref:troubleshooting.adoc[]
+
 .Reference
 * xref:api-ref.adoc[]
 * xref:phone-homes.adoc[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -30,7 +30,7 @@ By using Operator, teams can benefit from a more streamlined, automated, and Kub
 
 == Supported versions
 
-Operator only supports Enterprise Edition deployments of Hazelcast Platform. Community Edition does not support Operator.  
+Operator only supports Enterprise Edition deployments of Hazelcast Platform. Community Edition does not support Operator.
 
 === Kubernetes versions
 
@@ -39,6 +39,18 @@ Operator supports Kubernetes versions 1.26 - 1.35.
 === OpenShift versions
 
 Operator supports OpenShift versions 4.12 - 4.21.
+
+== What Operator deploys
+
+When you apply a `Hazelcast` custom resource (CR), Operator creates member pods containing these containers:
+
+* `hazelcast`: the Hazelcast Platform member itself. It handles clustering, data storage, and query processing.
+* `sidecar-agent`: a long-running helper that Operator communicates with at runtime to download Jet job JARs, download User Code Namespace bundles, and upload backups to external buckets (AWS S3, GCP, and Azure Blob).
+* `init-container`: a helper that runs once before the member starts, to download user code and modules from external buckets, URLs, and ConfigMaps, and to restore backups into the member's storage.
+
+The `sidecar-agent` and `init-container` run from the same agent image, which you can configure through the `agent` configuration field. See xref:image-registry.adoc[] and xref:resource-configuration.adoc[].
+
+Because these helper containers perform tasks such as authenticating to buckets and downloading files, some errors -- particularly failures downloading Jet job JARs or User Code Namespace bundles -- are recorded only in the container logs, and not in the custom resource status. For guidance on reading these logs, see xref:troubleshooting.adoc[].
 
 == Get started
 

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -20,6 +20,13 @@ To diagnose problems with Management Center, use:
 kubectl logs <management-center-pod> -c management-center
 ----
 
+The Operator can sometimes fail to reconcile the CR. To troubleshoot problems related to this, see the Operator's own logs. Replace `<operator-namespace>` with the namespace where you deployed Operator, for example `hz-system`:
+
+[source,bash]
+----
+kubectl logs -l app.kubernetes.io/name=hazelcast-platform-operator -n <operator-namespace>
+----
+
 == See also
 
 * xref:configure-diagnostic-logging.adoc[] -- for enabling detailed diagnostics on the Hazelcast _member_ (a separate feature from the container logs above).

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -1,0 +1,26 @@
+= Finding logs
+:description: This page describes how to find logs for a Hazelcast cluster deployed with Operator.
+
+{description}
+
+The relevant logs may be in one of several places, depending on the issue you are troubleshooting.
+
+By default, `kubectl logs <pod>` shows only the first container. To see logs for the helper containers (see xref:index.adoc[What Operator deploys]), name them explicitly with `-c`:
+
+[source,bash]
+----
+kubectl logs <hazelcast-pod> -c sidecar-agent
+kubectl logs <hazelcast-pod> -c init-container
+----
+
+To diagnose problems with Management Center, use:
+
+[source,bash]
+----
+kubectl logs <management-center-pod> -c management-center
+----
+
+== See also
+
+* xref:configure-diagnostic-logging.adoc[] -- for enabling detailed diagnostics on the Hazelcast _member_ (a separate feature from the container logs above).
+* xref:get-support.adoc[]


### PR DESCRIPTION
https://hazelcast.atlassian.net/browse/INBOX-1012

Adds a new Troubleshooting section, to match Platform and MC.
Provides info about the helper containers and their logs.